### PR TITLE
faq: kleine aanpassing in "Voor wie is ORI-A bedoeld?"

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -41,7 +41,7 @@ ORI-A is bedoeld voor iedereen die betrokken is bij de duurzame toegankelijkheid
 - Leveranciers die hun producten of diensten willen afstemmen op de behoeften vanuit de overheid.
 - Beheerders van raadsinformatiesystemen en andere functionarissen die betrokken zijn bij het migreren van raadsinformatie richting een e-depot. 
 
-Ten slotte kan ORI-A ook dienen als naslagwerk voor iedereen die gebruik wilt maken van door overheden gepubliceerde ORI-A metagegevens. Denk bijvoorbeeld aan applicatiebouwers die viewers of zoekmachines voor (openbare) raadsinformatie willen ontwikkelen.
+Ten slotte kan ORI-A ook dienen als naslagwerk voor iedereen die gebruik wil maken van door overheden gepubliceerde ORI-A metagegevens. Denk bijvoorbeeld aan applicatiebouwers die viewers of zoekmachines voor (openbare) raadsinformatie willen ontwikkelen.
 
 # Wanneer gebruik je ORI-A? 
 

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -41,7 +41,7 @@ ORI-A is bedoeld voor iedereen die betrokken is bij de duurzame toegankelijkheid
 - Leveranciers die hun producten of diensten willen afstemmen op de behoeften vanuit de overheid.
 - Beheerders van raadsinformatiesystemen en andere functionarissen die betrokken zijn bij het migreren van raadsinformatie richting een e-depot. 
 
-ORI-A kan ook worden gebruikt als naslagwerk voor iedereen die gebruik wil maken van de ORI-A metagegevens die door een overheidsorganisatie beschikbaar zijn gesteld. Zoals voor het koppelen van een zoekmachine aan (openbare) raadsinformatie of voor het bouwen van andere applicaties die toegang bieden tot raadsinformatie, zoals viewers. 
+Ten slotte kan ORI-A ook dienen als naslagwerk voor iedereen die gebruik wilt maken van door overheden gepubliceerde ORI-A metagegevens. Denk bijvoorbeeld aan applicatiebouwers die viewers of zoekmachines voor (openbare) raadsinformatie willen bouwen.
 
 # Wanneer gebruik je ORI-A? 
 

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -41,7 +41,7 @@ ORI-A is bedoeld voor iedereen die betrokken is bij de duurzame toegankelijkheid
 - Leveranciers die hun producten of diensten willen afstemmen op de behoeften vanuit de overheid.
 - Beheerders van raadsinformatiesystemen en andere functionarissen die betrokken zijn bij het migreren van raadsinformatie richting een e-depot. 
 
-Ten slotte kan ORI-A ook dienen als naslagwerk voor iedereen die gebruik wilt maken van door overheden gepubliceerde ORI-A metagegevens. Denk bijvoorbeeld aan applicatiebouwers die viewers of zoekmachines voor (openbare) raadsinformatie willen bouwen.
+Ten slotte kan ORI-A ook dienen als naslagwerk voor iedereen die gebruik wilt maken van door overheden gepubliceerde ORI-A metagegevens. Denk bijvoorbeeld aan applicatiebouwers die viewers of zoekmachines voor (openbare) raadsinformatie willen ontwikkelen.
 
 # Wanneer gebruik je ORI-A? 
 


### PR DESCRIPTION
Ik vond de laatste zin een beetje moeilijk lezen, dus die heb ik flink omgegooid. Ik hoop dat ik nog steeds zeg wat je bedoelde.

De zin daarvoor is een beetje lang en wollig — worden ORI-A gegevens ooit beschikbaar gesteld door particulieren?  Maar nu ie iets korter is vind ik m wel te doen. 