### PR TITLE
faq: Herschrijf "Waarom ORI-A" entry

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -19,6 +19,8 @@ ORI en ORI-A hebben vergelijkbare doelstellingen, waaronder het gestandaardiseer
 
 Toch waren er enkele redenen waarom een speciale archiefvariant van ORI nodig bleek:
 
+* **XML ondersteuning.** ORI is alleen beschikbaar in het [JSON bestandsformaat](https://en.wikipedia.org/wiki/JSON). Alhoewel er niks mis is met JSON, ondersteunen e-depots en de software die archiefinstellingen gebruiken meestal alleen XML. Door een XML standaard en [aansluitend validatie-schema](https://en.wikipedia.org/wiki/XML_Schema_(W3C)) te ontwikkelen --- [de ORI-A XSD](downloads) --- sluit ORI-A beter aan op gewoontes in de archiefwereld.
+
 * **Aansluiten bij bestaande (archief)standaarden.** [Het Nationaal Archief raadt aan](https://www.nationaalarchief.nl/archiveren/mdto#collapse-102790) algemene gegevens over informatieobjecten --- zoals aanmaakdatum en auteur --- vast te leggen in MDTO, een metadatastandaard gericht op het duurzaam toegangelijk maken van overheidsdocumenten. In tegenstelling tot ORI is ORI-A zo ontwikkelt dat deze taak volledig bij MDTO blijft.  ORI-A richt zich daarentegen uitsluitend op **domeinspecifieke gegevens** --- oftewel, raadsinformatie.
 
 ::: tip
@@ -29,7 +31,6 @@ Je kunt meer lezen over het combineren van ORI-A en MDTO in [Hoe werkt ORI-A?](t
 
 * **Duurzame toegangelijkheid.** Sommige gegevens in ORI, zoals de datum waarop een vergadering gehouden is, zijn essentieel voor de toekomstige interpreteerbaarheid van raadsinformatie, maar niet verplicht. Om de [duurzame toegangelijkheid](https://www.nationaalarchief.nl/archiveren/kennisbank/duurzaam-toegankelijk) van raadsinformatie te waarborgen zijn zulke gegevens in ORI-A wél verplicht gesteld.
 
-* **XML ondersteuning.** ORI is alleen beschikbaar in het [JSON bestandsformaat](https://en.wikipedia.org/wiki/JSON). Alhoewel er niks mis is met JSON, ondersteunen e-depots en de software die archiefinstellingen gebruiken meestal alleen XML. Door een XML standaard en [aansluitend validatie-schema](https://en.wikipedia.org/wiki/XML_Schema_(W3C)) te ontwikkelen --- [de ORI-A XSD](downloads) --- sluit ORI-A beter aan op gewoontes in de archiefwereld.
 
 # Waarom heeft ORI-A geen aggregatieniveaus?
 

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -27,7 +27,7 @@ Toch waren er enkele redenen waarom een speciale archiefvariant van ORI nodig bl
 Je kunt meer lezen over het combineren van ORI-A en MDTO in [Hoe werkt ORI-A?](tutorial#mdto)
 :::
 
-* **Flexibiliteit.** ORI vereist soms informatie die niet altijd in de gevraagde vorm beschikbaar bleek. Dit probleem komt vooral voor bij raadsinformatie die is aangemaakt _voordat_ de VNG met ORI begon. Omdat archieven deze oudere vergaderingen alsnog gestandaardiseerd willen opslaan, was een flexibelere standaard nodig.
+* **Achterwaartse compatibiliteit (_backwards compatibility_).**  Bestaande raadsinformatie voldoet niet altijd aan alle eisen van ORI. Uit analyses van RIS systemen kwam bijvoorbeeld naar voren dat ORI soms gegevens vereist die ofwel niet beschikbaar zijn, ofwel niet beschikbaar zijn in de gevraagde vorm. Dit komt vooral voor bij **oudere vergaderingen**. Omdat ook deze vergaderingen gearchiveerd moeten worden, is ORI-A flexiber gemaakt op punten waar RIS systemen momenteel tekort schieten.
 
 * **Duurzame toegangelijkheid.** Sommige gegevens in ORI, zoals de datum waarop een vergadering gehouden is, zijn essentieel voor de toekomstige interpreteerbaarheid van raadsinformatie, maar niet verplicht. Om de [duurzame toegangelijkheid](https://www.nationaalarchief.nl/archiveren/kennisbank/duurzaam-toegankelijk) van raadsinformatie te waarborgen zijn zulke gegevens in ORI-A wél verplicht gesteld.
 

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -13,13 +13,23 @@ Een **videotuul** (samenvoeging van "video" en "notulen") is een audiovisueel ve
 
 Strikt genomen zijn overheden niet altijd verplicht om videotulen te bewaren. Als er ook schriftelijke verslagen zijn van vergaderingen, dan hoort de meest informatierijke bron te worden bewaard. Vanuit cultuurhistorisch oogpunt is het wel belangrijk dat videotulen permanent bewaard worden. Videotulen zijn een belangrijk onderdeel van de digitale democratie.
 
-# Waarom is ORI-A ontwikkeld?
+# Waarom een speciale archiefstandaard?
 
-ORI-A is ontwikkeld als domeinspecifieke standaard voor raadsinformatie, wanneer dit voor permanente bewaring naar een [e-depot](https://www.nationaalarchief.nl/archiveren/kennisbank/wat-is-een-e-depot) wordt gemigreerd. Om videotulen op een [duurzaam toegankelijke](https://www.nationaalarchief.nl/archiveren/kennisbank/duurzaam-toegankelijk) manier te kunnen beheren en beschikbaar stellen. Om migratie van raadsinformatie uniformer en efficiënter te maken, en zeker te zijn dat de juiste metagegevens meekomen.
+ORI-A is ontwikkelt met hetzelfde doel als ORI: het gestandaardiseerd beschikbaar stellen van raadsinformatie.
 
-# Waarom is ORI-A een XML-schema?
+Toch zijn er redenen waarom een speciale archiefvariant van ORI noodzakelijk was:
 
-ORI-A is als XML Schema Document (XSD) ontworpen, zodat het gezamenlijk met [MDTO](https://www.nationaalarchief.nl/archiveren/mdto) kan worden gebruikt bij migraties naar het e-depot. Metagegevens over informatieobjecten en bestanden kunnen dan in MDTO worden uitgedrukt, en metagegevens over raadsinformatie in ORI-A.
+* **Aansluiten bij bestaande (archief)standaarden.** [Het Nationaal Archief raadt aan](https://www.nationaalarchief.nl/archiveren/mdto#collapse-102790) algemene gegevens over informatieobjecten --- zoals aanmaakdatum en auteur --- vast te leggen in MDTO, een metadatastandaard gericht op het duurzaam toegangelijk maken van overheidsdocumenten. In tegenstelling tot ORI is ORI-A zo ontwikkelt dat deze taak volledig bij MDTO blijft.  ORI-A richt zich daarentegen uitsluitend op **domeinspecifieke gegevens** --- oftewel, raadsinformatie.
+
+::: tip
+Je kunt meer lezen over het combineren van ORI-A en MDTO in [Hoe werkt ORI-A?](tutorial#mdto)
+:::
+
+* **Flexibiliteit.** ORI vereist soms informatie die niet altijd in de gevraagde vorm beschikbaar bleek. Dit probleem komt vooral voor bij raadsinformatie die is aangemaakt _voordat_ de VNG met ORI begon. Omdat archieven deze oudere vergaderingen alsnog gestandaardiseerd willen opslaan, was een flexibelere standaard nodig.
+
+* **Duurzame toegangelijkheid.** Sommige gegevens in ORI, zoals de datum waarop een vergadering gehouden is, zijn essentieel voor de toekomstige interpreteerbaarheid van raadsinformatie, maar niet verplicht. Om de [duurzame toegangelijkheid](https://www.nationaalarchief.nl/archiveren/kennisbank/duurzaam-toegankelijk) van raadsinformatie te waarborgen zijn zulke gegevens in ORI-A wél verplicht gesteld.
+
+* **XML ondersteuning.** ORI is alleen beschikbaar in het [JSON bestandsformaat](https://en.wikipedia.org/wiki/JSON). Alhoewel er niks mis is met JSON, ondersteunen e-depots en de software die archiefinstellingen gebruiken meestal alleen XML. Door een XML standaard en [aansluitend validatie-schema](https://en.wikipedia.org/wiki/XML_Schema_(W3C)) te ontwikkelen --- [de ORI-A XSD](downloads) --- sluit ORI-A beter aan op gewoontes in de archiefwereld.
 
 # Waarom heeft ORI-A geen aggregatieniveaus?
 

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -15,9 +15,9 @@ Strikt genomen zijn overheden niet altijd verplicht om videotulen te bewaren. Al
 
 # Waarom een speciale archiefstandaard?
 
-ORI-A is ontwikkelt met hetzelfde doel als ORI: het gestandaardiseerd beschikbaar stellen van raadsinformatie.
+ORI en ORI-A hebben vergelijkbare doelstellingen, waaronder het gestandaardiseerd beschikbaarstellen van raadsinformatie.
 
-Toch zijn er redenen waarom een speciale archiefvariant van ORI noodzakelijk was:
+Toch waren er enkele redenen waarom een speciale archiefvariant van ORI nodig bleek:
 
 * **Aansluiten bij bestaande (archief)standaarden.** [Het Nationaal Archief raadt aan](https://www.nationaalarchief.nl/archiveren/mdto#collapse-102790) algemene gegevens over informatieobjecten --- zoals aanmaakdatum en auteur --- vast te leggen in MDTO, een metadatastandaard gericht op het duurzaam toegangelijk maken van overheidsdocumenten. In tegenstelling tot ORI is ORI-A zo ontwikkelt dat deze taak volledig bij MDTO blijft.  ORI-A richt zich daarentegen uitsluitend op **domeinspecifieke gegevens** --- oftewel, raadsinformatie.
 

--- a/pages/over-ori-a.md
+++ b/pages/over-ori-a.md
@@ -9,7 +9,9 @@ position: 1
 
 # Wat is ORI•A?
 
-De Open Raadsinformatie Archiefstandaard (ORI-A) beschrijft de regels voor het duurzaam bewaren van raadsinformatie in XML-formaat. ORI-A is gebaseerd op het informatiemodel onder de [Open Raadsinformatie (ORI) API specificatie](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie).
+De Open Raadsinformatie Archiefstandaard (ORI-A) beschrijft de regels voor het duurzaam bewaren van raadsinformatie in XML-formaat. Dit XML-formaat kan gebruikt worden wanneer raadsinformatie, zoals een collectie videotulen, voor permanente bewaring naar een [e-depot](https://www.nationaalarchief.nl/archiveren/kennisbank/wat-is-een-e-depot) wordt gemigreerd. 
+
+ORI-A is gebaseerd op het informatiemodel onder de [Open Raadsinformatie (ORI) API specificatie](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie).
 
 ## Achtergrond
 
@@ -21,8 +23,15 @@ De werkgroep heeft twee doelen: het ontwikkelen, testen en gebruiksklaar maken v
 
 De ORI-A XSD is momenteel in bèta, en [kan hier gedownload worden](https://github.com/Regionaal-Archief-Rivierenland/ORI-XSD/releases). De standaard wordt de komende tijd getest aan enkele praktijkcases en op basis daarvan aangepast. Wijzigingen op de ORI-A XSD ten gevolge van deze tests worden op [GitHub](https://github.com/Regionaal-Archief-Rivierenland/ORI-A-XSD) bijgehouden.
 
-## Documentatie
+# Waarom is ORI-A ontwikkeld?
 
+ORI-A heeft een vergelijkbaar doel als het ORI-project geleid door de VNG: het gestandaardiseerd beschikbaar stellen van raadsinformatie. Deze standaardisatie slag is hard nodig, omdat ieder RIS-systeem momenteel een eigen, niet-publiekelijk gedocumenteerd formaat voor raadsinformatie hanteert. Hiermee komt de toekomstige **vindbaarheid** en **interpreteerbaarheid** van raadsinformatie in gevaar.
+
+Toch kon VNG's ORI niet aan alle behoeften van archieven voldoen. Hierom is besloten een archiefvariant van ORI te ontwikkelen. Je kan hier meer over lezen in [Waarom een speciale archiefstandaard?](faq).
+
+# Documentatie
+
+<!-- todo: benoem downloads pagina, het plaatje, en de voor mensen bedoelde documentatie   -->
 De documentatie van de XSD is een work-in-progress. De betekenis van de verschillende (sub)elementen kan op dit moment achterhaald worden uit de waardes binnen de `<xs:documentation>` tags.
 
 Bovendien bestaat er een [grafische representatie van het informatiemodel.](ORI-A-diagram.pdf)


### PR DESCRIPTION
Deze entry focust nu specifiek op waarom ORI niet toereikend was voor de archiefsector, en waarom er dus voor een speciale ("dedicated") archiefstandaard gekozen is. Waarom een standaard überhaupt nuttig is, en dat de bestaansreden van ORI-A ook iets te maken heeft met het kunnen migreren van data naar een eDepot, staat nu op de landingspagina. Dat lijkt me allemaal voorpagina nieuws.

Eerst was er in deze entry iets meer nadruk op migreren. Ik vind het op zich goed om dat er in te houden, maar vond het lastig om daar beknopt iets over te schrijven. 

Het beste wat ik kon maken was iets te lang:

* **Korte termijn migratie naar archiefbewaarplaats.** VNG's beoogt met ORI de online onsluiting van raadsinformatie via een API. Momenteel biedt echter geen enkele RIS leverancier hun volledige data aan via zo'n API --- hoogstens kleine gedeeltes. Toch willen sommige overheden raadsinformatie in alle volligheid migrigeren naar een archiefbewaarplaats. ORI-A springt in dit gat door RIS leveranciers niet te vragen een relatief complexe API te implementeren, maar simpelweg een export van hun data aan te bieden. Deze export kan vervolgens gemakkelijk door een archiefinstellingen, RIS-leverancier of derde partij omgezet worden naar ORI-A XML, bijvoorbeeld via deze ORI-A python library.
