### PR TITLE
faq: werk verhouding ORI en ORI-A verder uit

### DIFF
--- a/pages/faq.md
+++ b/pages/faq.md
@@ -29,9 +29,15 @@ De hoofdreden voor deze relatief 'platte' structuur is dat de objecten in ORI, h
 
 # Hoe verhoudt ORI-A zich tot ORI?
 
-ORI-A is gebaseerd op het informatiemodel dat is ontworpen voor de [Open Raadsinformatie (ORI) API](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie). Op sommige vlakken is besloten af te wijken van dit informatiemodel. ORI-A biedt in tegenstelling tot ORI geen ruimte voor gegevens over informatieobjecten, maar verwijst op die momenten naar MDTO. Ook zijn sommige verplichtingen verschillend. Een volledige lijst van de verschillen wordt nog opgemaakt.
+ORI-A is gebaseerd op het informatiemodel dat is ontworpen voor de [Open Raadsinformatie (ORI) API](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie). Dit informatiemodel is op sommige punten aangepast aan de behoeftes van archieven. ORI-A biedt in tegenstelling tot ORI geen ruimte voor gegevens over informatieobjecten, maar verwijst op die momenten naar MDTO. Ook zijn sommige verplichtingen verschillend. Een volledige lijst van de verschillen wordt nog opgemaakt.
 
-Voor meer achtergrondinformatie over ORI, zie [hier](https://ontola.io/nl/cases/openbesluitvorming/) en [hier](https://openstate.eu/nl/projecten-tools-data/besluiten/open-raadsinformatie/).
+Ondanks deze kleine aanpassingen is wel geprobeerd ORI-A **interoperabel** te houden met ORI. Formeler gezegd: je kan ORI zonder informatieverlies converteren naar een combinatie van ORI-A en MDTO (zie ook [round-trip format conversion](https://en.wikipedia.org/wiki/Round-trip_format_conversion)). De andere kant op (ORI-A + MDTO → ORI) kan ook, maar dan treed mogelijk informatieverlies op, aangezien ORI-A + MDTO een _superset_ is van ORI.
+
+::: waarschuwing
+Meer achtergrondinformatie over ORI kun je vinden op [de website van de ontwikkelaars van openbesluitvorming.nl](https://ontola.io/nl/cases/openbesluitvorming/) en [de website van ](https://openstate.eu/nl/projecten-tools-data/besluiten/open-raadsinformatie/).
+:::
+
+<!-- todo: benoem conversie scripts wanneer die af zijn -->
 
 # Voor wie is ORI-A bedoeld? 
 


### PR DESCRIPTION
> Op sommige vlakken is besloten af te wijken van dit informatiemodel

Ik denk dat je bedoeld: "ORI-A heeft nieuwe coole archiefgerichte features" ;) 

Ik link op een gegeven moment naar  [round-trip format conversion](https://en.wikipedia.org/wiki/Round-trip_format_conversion), maar idk of dat nodige informatie is. 

Ook bevat de alinea over interoperabiliteit misschien meer jargon dan normaal gewenst. Anderzijds denk ik dat je helaas wat jargon moet accepteren als je verschillen tussen informativeness wilt uitdrukken. 
