### PR TITLE
Defunct - uniformeren headers en hun teksten

### DIFF
--- a/pages/begrippenlijsten.md
+++ b/pages/begrippenlijsten.md
@@ -2,10 +2,12 @@
 title: Begrippenlijsten
 position: 4
 ---
+<!-- Het lijkt me een goed idee om te beginnen met een algemeen stuk over het hoe en waarom van begrippenlijsten en hun nut bij standaardisatie. Eventueel met link naar de MDTO en TOOI begrippenlijsten. -->
+
+Op deze pagina is informatie te vinden over de momenten waarop ORI•A gebruik maakt van begrippenlijsten. Een begrippenlijst is een manier om gegevens te relateren aan een extern vastgestelde (gecontroleerde) lijst van waarden. ORI•A volgt de definitie, semantiek en toepassing van begrippenlijsten zoals die ook in [MDTO](https://www.nationaalarchief.nl/archiveren/mdto/begripbegrippenlijst) worden gehanteerd.
+
 
 # Begrippenlijsten gebruiken
-
-<!-- Het lijkt me een goed idee om te beginnen met een algemeen stuk over het hoe en waarom van begrippenlijsten en hun nut bij standaardisatie. Eventueel met link naar de MDTO en TOOI begrippenlijsten. -->
 
 Een begrippenlijst roep je zo aan:
 
@@ -21,7 +23,7 @@ Een begrippenlijst roep je zo aan:
 
 Alle begrippenlijsten die onderdeel zijn van **ORI•A** worden hieronder gedocumenteerd.
 
-## TOOI Begrippenlijsten
+## TOOI begrippenlijsten
 
 Een paar begrippenlijsten die van toepassing zijn op **ORI•A** worden beheerd door **TOOI**, [een standaardisatie project opgezet door de Rijksoverheid](https://standaarden.overheid.nl/tooi/doc/tooi-registers/):
 
@@ -29,7 +31,8 @@ Een paar begrippenlijsten die van toepassing zijn op **ORI•A** worden beheerd 
 * [Begrippenlijst Waterschappen](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
 * [Begrippenlijst Provincie](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
 
-# Vergaderstuk types
+
+# Vergaderstuktypes
 
 Binnen ORI-A zijn de volgende vergaderstuktypes gedefinieerd. Deze types kunnen worden toegevoegd bij een verwijzing naar een informatieobject, zoals `<heeftAlsBijlage>`. Voor meer informatie, zie [Gebruik van ORI-A met MDTO](tutorial#gebruik-van-ori-a-met-mdto).
 
@@ -74,8 +77,6 @@ De rol "Overig" bestaat om compatibiliteit met het oorspronkelijke ORI informati
 # Betrokkene-vergaderstuk relaties
 
 Een lijst met verschillende soorten relaties tussen personen en vergaderstukken. Relevant binnen MDTO om het soort relatie tussen een `<betrokkene>` en een informatieobject vast te leggen (zie [`mdto:betrokkeneTypeRelatie`](https://www.nationaalarchief.nl/archiveren/mdto/betrokkeneTypeRelatie)).
-
-
 
 <!-- ``` xml
 <informatieobject>

--- a/pages/begrippenlijsten.md
+++ b/pages/begrippenlijsten.md
@@ -45,7 +45,6 @@ Binnen ORI-A zijn de volgende vergaderstuktypes gedefinieerd. Deze types kunnen 
 | Vraag      | Vraag aan de raad.                                                         |
 | Antwoord   | Antwoord op een vraag aan de raad.                                         |
 
-
 # Deelnemerrollen
 
 Binnen ORI-A zijn de enkele rollen waarin een `<aanwezigeDeelnemer>` in een vergadering aanwezig kan zijn gedefinieerd:
@@ -59,22 +58,21 @@ De rol "Overig" bestaat om compatibiliteit met het oorspronkelijke ORI informati
 
 :::
 
+| Label                 | Definitie                                                                  |
+|:----------------------|:---------------------------------------------------------------------------|
+| Voorzitter            | De voorzitter van de vergadering.                                          |
+| Vice-voorzitter       | De vice-voorzitter van de vergadering.                                     |
+| Portefeuillehouder    | Ambtenaar die de verantwoordelijkheid draagt over een besproken onderwerp. |
+| Griffier              | Hoofd van het griffie.                                                     |
+| Raadslid              | Gekozen volksvertegenwoordiger binnen een gemeente.                        |
+| Statenlid             | Gekozen volksvertegenwoordiger binnen een provincie.                       |
+| Kamerlid              | Gekozen volksvertegenwoordiger binnen de Eerste of Tweede Kamer.           |
+| Dagelijks bestuurslid | Lid van een dagelijks bestuur.                                             |
+| Algemeen bestuurslid  | Lid van een algemeen bestuur.                                              |
+| Inspreker             | Niet-lid dat inspreekt tijdens de vergadering.                             |
+| <del>Overig</del>     | -                                                                          |
 
-| Label                 | Definitie                                                              |
-|:----------------------|:-----------------------------------------------------------------------|
-| Voorzitter            | De voorzitter van de vergadering.                                      |
-| Vice-voorzitter       | De vice-voorzitter van de vergadering.                                 |
-| Portefeuillehouder    | Ambtenaar die de verantwoordelijk draagt over een besproken onderwerp. |
-| Griffier              | Hoofd van het griffie.                                                 |
-| Raadslid              | Gekozen volksvertegenwoordiger binnen een gemeente.                    |
-| Statenlid             | Gekozen volksvertegenwoordiger binnen een provincie.                   |
-| Kamerlid              | Gekozen volksvertegenwoordiger binnen de eerst of tweede kamer.        |
-| Dagelijks bestuurslid | Lid van een dagelijks bestuur.                                         |
-| Algemeen bestuurslid  | Lid van het algemeen bestuur van een waterschap.                       |
-| Inspreker             | Niet-lid dat inspreekt tijdens de vergadering.                         |
-| <del>Overig</del>     | -                                                                      |
-
-# Betrokkene-vergaderstuk relaties
+# Betrokkene - vergaderstuk relaties
 
 Een lijst met verschillende soorten relaties tussen personen en vergaderstukken. Relevant binnen MDTO om het soort relatie tussen een `<betrokkene>` en een informatieobject vast te leggen (zie [`mdto:betrokkeneTypeRelatie`](https://www.nationaalarchief.nl/archiveren/mdto/betrokkeneTypeRelatie)).
 
@@ -103,20 +101,18 @@ Een lijst met verschillende soorten relaties tussen personen en vergaderstukken.
 </informatieobject>
 ```
 -->
-| Label              | Definitie                                                    |
-|:-------------------|:-------------------------------------------------------------|
-| Indiener           | Indiener van een vergaderstuk (herkomst: VNG's ORI).         |
-| Ondertekenaar      | Ondertekenaar van een vergaderstuk (herkomst: VNG's ORI).    |
-| Portefeuillehouder | De portefeuillehouder van een voorstel (herkomst: VNG's ORI) |
+| Label              | Definitie                                                              |
+|:-------------------|:-----------------------------------------------------------------------|
+| Indiener           | Indiener van een vergaderstuk (herkomst: ORI-informatiemodel).         |
+| Ondertekenaar      | Ondertekenaar van een vergaderstuk (herkomst: ORI-informatiemodel).    |
+| Portefeuillehouder | De portefeuillehouder van een voorstel (herkomst: ORI-informatiemodel) |
 
 # Mediabron types
 
 Deze lijst beschrijft de meest gangbare mediaformaten waarin vergaderingen worden vastgesteld. Deze waardes kun je gebruiken onder `<informatieobjectType>`, als het informatieobject waarnaar je verwijst een mediabron is.
 
-
 | Label        | Definitie                                                                   |
 |:-------------|:----------------------------------------------------------------------------|
-| Video        | Een audiovisuele opname van een vergadering. Ookwel 'videotuul'.            |
 | Audio        | Een geluidsopname van een vergadering. Ookwel 'audiotuul'.                   |
 | Transcriptie | Een schriftelijk uitverwerking van de gesproken inhoud van een vergadering. |
 

--- a/pages/begrippenlijsten.md
+++ b/pages/begrippenlijsten.md
@@ -6,6 +6,7 @@ position: 4
 
 Op deze pagina is informatie te vinden over de momenten waarop ORI•A gebruik maakt van begrippenlijsten. Een begrippenlijst is een manier om gegevens te relateren aan een extern vastgestelde (gecontroleerde) lijst van waarden. ORI•A volgt de definitie, semantiek en toepassing van begrippenlijsten zoals die ook in [MDTO](https://www.nationaalarchief.nl/archiveren/mdto/begripbegrippenlijst) worden gehanteerd.
 
+Waar mogelijk maakt ORI-A gebruik van begrippenlijsten van **TOOI**, [een standaardisatieproject opgezet door de Rijksoverheid](https://standaarden.overheid.nl/tooi/doc/tooi-registers/). In andere gevallen beheert ORI-A voorlopig eigen begrippenlijsten.
 
 # Begrippenlijsten gebruiken
 
@@ -21,16 +22,15 @@ Een begrippenlijst roep je zo aan:
 </vergaderstukType>
 ```
 
-Alle begrippenlijsten die onderdeel zijn van **ORI•A** worden hieronder gedocumenteerd.
-
 ## TOOI begrippenlijsten
 
-Een paar begrippenlijsten die van toepassing zijn op **ORI•A** worden beheerd door **TOOI**, [een standaardisatie project opgezet door de Rijksoverheid](https://standaarden.overheid.nl/tooi/doc/tooi-registers/):
+Een paar begrippenlijsten die van toepassing zijn op **ORI-A** worden beheerd door **TOOI**:
 
 * [Begrippenlijst Gemeentes](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
 * [Begrippenlijst Waterschappen](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
 * [Begrippenlijst Provincie](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
 
+Alle begrippenlijsten die onderdeel zijn van **ORI-A** worden hieronder gedocumenteerd.
 
 # Vergaderstuktypes
 
@@ -47,14 +47,14 @@ Binnen ORI-A zijn de volgende vergaderstuktypes gedefinieerd. Deze types kunnen 
 
 # Deelnemerrollen
 
-Binnen ORI-A zijn de enkele rollen waarin een `<aanwezigeDeelnemer>` in een vergadering aanwezig kan zijn gedefinieerd:
+Binnen ORI-A zijn de rollen gedefinieerd waarin een `<aanwezigeDeelnemer>` in een vergadering aanwezig kan zijn:
 
 ::: waarschuwing
-De rol "Overig" bestaat om compatibiliteit met het oorspronkelijke ORI informatiemodel te garanderen. Het gebruik van deze rol wordt afgeraden. Als de bestaande rollen niet toereikend zijn, heb je drie opties:
+De rol "Overig" bestaat om compatibiliteit met het oorspronkelijke ORI-informatiemodel te garanderen. Het gebruik van deze rol wordt afgeraden. Als de bestaande rollen niet toereikend zijn, heb je de volgende opties:
 
 1. Een uitbreiding op deze begrippenlijst [aanvragen](https://github.com/Regionaal-Archief-Rivierenland/ORI-A-Website/issues/new)
 2. Een nieuwe begrippenlijst starten
-3. Deze begrippenlijst uitbreiden
+<!-- 3. Als we een onderscheid gaan maken tussen open en gesloten begrippenlijsten kan hier mogelijk nog een optie bij) -->
 
 :::
 
@@ -113,7 +113,8 @@ Deze lijst beschrijft de meest gangbare mediaformaten waarin vergaderingen worde
 
 | Label        | Definitie                                                                   |
 |:-------------|:----------------------------------------------------------------------------|
-| Audio        | Een geluidsopname van een vergadering. Ookwel 'audiotuul'.                   |
-| Transcriptie | Een schriftelijk uitverwerking van de gesproken inhoud van een vergadering. |
+| Video        | Een audiovisuele opname van een vergadering. Ook wel 'videotuul'.           |
+| Audio        | Een geluidsopname van een vergadering. Ook wel 'audiotuul'.                 |
+| Transcriptie | Een schriftelijke uitwerking van de gesproken inhoud van een vergadering.   |
 
 

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -27,12 +27,16 @@ ORI en ORI-A hebben vergelijkbare doelstellingen, waaronder het gestandaardiseer
 
 Toch waren er enkele redenen waarom een speciale archiefvariant van ORI nodig bleek:
 
-* **XML ondersteuning.** ORI is alleen beschikbaar in het [JSON bestandsformaat](https://en.wikipedia.org/wiki/JSON). Alhoewel er niks mis is met JSON, ondersteunen e-depots en de software die archiefinstellingen gebruiken meestal alleen XML. Door een XML standaard en [aansluitend validatie-schema](https://en.wikipedia.org/wiki/XML_Schema_(W3C)) te ontwikkelen --- [de ORI-A XSD](downloads) --- sluit ORI-A beter aan op gewoontes in de archiefsector.
+* **XML ondersteuning.** 
+ORI is alleen beschikbaar in het [JSON bestandsformaat](https://en.wikipedia.org/wiki/JSON). Alhoewel er niks mis is met JSON, ondersteunen e-depots en de software die archiefinstellingen gebruiken meestal alleen XML. Door het ORI-A [XML-schema](downloads) te ontwikkelen, wordt beter aangesloten op gewoontes in de archiefsector.
 
-* **Aansluiten bij bestaande (archief)standaarden.** [Het Nationaal Archief raadt aan](https://www.nationaalarchief.nl/archiveren/mdto#collapse-102790) algemene gegevens over informatieobjecten --- zoals aanmaakdatum en auteur --- vast te leggen in MDTO, een metadatastandaard gericht op het duurzaam toegangelijk maken van overheidsdocumenten. In tegenstelling tot ORI is ORI-A zo ontwikkeld dat deze taak volledig bij MDTO blijft.  ORI-A richt zich daarentegen uitsluitend op **domeinspecifieke gegevens** --- oftewel, raadsinformatie.
+* **Aansluiten bij bestaande (archief)standaarden.** 
+Het Nationaal Archief beheert [MDTO](https://www.nationaalarchief.nl/archiveren/mdto#collapse-102790) als norm voor het vastleggen en uitwisselen van metagegevens van overheidsinformatie, waarvoor ook een [XML-schema](https://www.nationaalarchief.nl/archiveren/mdto/xml-schema) is ontwikkeld. In dit schema staan de entiteiten informatieobject en bestand centraal. MDTO wordt veel gebruikt bij het migreren van overheidsinformatie naar archiefdiensten.
+
+In het ORI-informatiemodel staan veel gegevens over informatieobjecten. Deze gegevens zijn weggelaten uit ORI-A en vervangen door verwijzingen naar MDTO. Beide standaarden zijn hierdoor goed samen bruikbaar. ORI-A richt zich dus uitsluitend op **domeinspecifieke gegevens**: raadsinformatie.
 
   ::: tip
-  **Tip:** Je kunt meer lezen over het combineren van ORI-A en MDTO in [Hoe werkt ORI-A?](tutorial#mdto)
+  **Tip:** Je kunt meer lezen over het combineren van ORI-A en MDTO in de praktijk in [Hoe werkt ORI-A?](tutorial#mdto)
   :::
 
 * **Achterwaartse compatibiliteit (_backwards compatibility_).**  Bestaande raadsinformatie voldoet niet altijd aan alle eisen van het ORI-informatiemodel. Uit analyses van RIS-systemen kwam bijvoorbeeld naar voren dat ORI soms gegevens vereist die ofwel niet beschikbaar zijn, ofwel niet beschikbaar zijn in de gevraagde vorm. Dit komt vooral voor bij **oudere vergaderingen**. Omdat ook deze vergaderingen gearchiveerd moeten worden, is ORI-A op bepaalde punten flexibeler (zie ook [Hoe verhoudt ORI-A zich tot ORI](faq#hoe-verhoudt-ori-a-zich-tot-ori)).
@@ -41,10 +45,11 @@ Toch waren er enkele redenen waarom een speciale archiefvariant van ORI nodig bl
 
 # Waarom heeft ORI•A geen aggregatieniveaus?
 
+In tegenstelling tot MDTO kent ORI-A geen aggregatieniveaus, en ook relatief weinig hiërarchie. ORI-A draait om de entiteit vergadering, maar lang niet alle entiteiten van ORI-A zijn daaronder beschreven. 
 
-ORI-A draait om de entiteit vergadering. Deze vergadering is niet verder opgesplitst in hiërarchisch gestructureerde niveaus, ook wel bekend als 'aggregatieniveaus'. 
+De hoofdreden voor deze relatief platte structuur is dat entiteiten in het ORI-informatiemodel bijna allemaal **meervoudige relaties** hebben. Om een voorbeeld te noemen: een aanwezige deelnemer neemt weliswaar deel aan een vergadering, maar kan net zo goed deelnemen aan een stemming, of spreken tijdens een agendapunt. Door deze verstrengelingen lijkt een raadsvergadering meer op een spinnenweb dan een hiërarchische boomstructuur.
 
-De hoofdreden voor deze relatief platte structuur is dat entiteiten in het  oorspronkelijke ORI informatiemodel bijna allemaal **meervoudige relaties** hebben. Om een voorbeeld te noemen: een raadsvoorstel is weliswaar een onderdeel van een vergadering, maar kan net zo goed onderdeel zijn van iemand's portefeuille, een stemming teweeg brengen, of ondertekend worden door een groep personen. Door deze verstrengelingen lijkt een raadsvergadering meer op een spinnenweb dan een hiërarchische boomstructuur.
+<!-- "Voor sommige e-depots is het handig als ORI-A XML-bestanden bij het opmaken van een levering worden opgeknipt en verspreid over de aggregatieniveaus in een MDTO sidecar-structuur. Zie hiervoor de voorbeeldimplementatie van ELO" (Hier een link opnemen naar de voorbeeldbestanden van ELO, waarin ORI-A gegevens in de MDTO aggregatieniveaus is onderverdeeld) -->
 
 # Hoe verhoudt ORI•A zich tot ORI?
 
@@ -53,7 +58,7 @@ ORI-A is gebaseerd op het informatiemodel dat is ontworpen voor de [Open Raadsin
 Ondanks deze kleine aanpassingen is wel geprobeerd ORI-A **interoperabel** te houden met ORI. Formeler gezegd: je kan ORI zonder informatieverlies converteren naar een combinatie van ORI-A en MDTO (zie ook [round-trip format conversion](https://en.wikipedia.org/wiki/Round-trip_format_conversion)). De andere kant op (ORI-A + MDTO → ORI) kan ook, maar dan treedt mogelijk informatieverlies op, aangezien ORI-A + MDTO een _superset_ is van ORI.
 
 ::: waarschuwing
-Meer achtergrondinformatie over ORI kun je vinden op [de website van de ontwikkelaars van openbesluitvorming.nl](https://ontola.io/nl/cases/openbesluitvorming/) en [de website van openstate.eu](https://openstate.eu/nl/projecten-tools-data/besluiten/open-raadsinformatie/).
+Meer achtergrondinformatie over de verschillende projecten rondom ORI kun je vinden op [de website van de ontwikkelaars van openbesluitvorming.nl](https://ontola.io/nl/cases/openbesluitvorming/) en [de website van openstate.eu](https://openstate.eu/nl/projecten-tools-data/besluiten/open-raadsinformatie/).
 :::
 
 <!-- todo: benoem conversiescripts wanneer die af zijn -->
@@ -77,4 +82,8 @@ ORI-A is toepasbaar in verschillende scenario’s:
 - **Bij het gebruiken van metagegevens:** met behulp van het XML-schema en het metagegevensschema kunnen gebruikers metadata lezen en interpreteren. 
 - **Bij het vormgeven van de presentatie van raadsinformatie in een e-depot:** ORI-A bevat in de basis alle benodigde data-elementen om de presentatie van raadsinformatie in onderlinge samenhang mogelijk te maken. 
 
+# Hoe spel je ORI•A? 
 
+ORI-A mag je zowel spellen met een bolletje (ORI•A) als met een streepje (ORI-A).
+
+Wanneer je gebruik wilt maken van het bolletje, gebruik dan het Unicode karakter [Bullet (U+2022)](https://www.compart.com/en/unicode/U+2022).

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -3,6 +3,8 @@ title: Veelgestelde vragen
 position: 5
 ---
 
+Hieronder worden vragen over ORI-A behandeld die niet pasten onder één van de andere rubrieken.
+
 # Wat is raadsinformatie, en wat is een videotuul?
 
 **Raadsinformatie** is een verzamelnaam voor alle digitale informatie die overheden aanmaken bij politieke en/of bestuurlijke besluitvorming. Deze besluitvorming vindt plaats in vergaderingen.
@@ -37,14 +39,14 @@ Toch waren er enkele redenen waarom een speciale archiefvariant van ORI nodig bl
 
 * **Duurzame toegankelijkheid.** Sommige gegevens in ORI, zoals de datum waarop een vergadering gehouden is, zijn essentieel voor de toekomstige interpreteerbaarheid van raadsinformatie, maar niet verplicht. Om de [duurzame toegankelijkheid](https://www.nationaalarchief.nl/archiveren/kennisbank/duurzaam-toegankelijk) van raadsinformatie te waarborgen zijn zulke gegevens in ORI-A wél verplicht gesteld.
 
+# Waarom heeft ORI•A geen aggregatieniveaus?
 
-# Waarom heeft ORI-A geen aggregatieniveaus?
 
 ORI-A draait om de entiteit vergadering. Deze vergadering is niet verder opgesplitst in hiërarchisch gestructureerde niveaus, ook wel bekend als 'aggregatieniveaus'. 
 
 De hoofdreden voor deze relatief platte structuur is dat entiteiten in het  oorspronkelijke ORI informatiemodel bijna allemaal **meervoudige relaties** hebben. Om een voorbeeld te noemen: een raadsvoorstel is weliswaar een onderdeel van een vergadering, maar kan net zo goed onderdeel zijn van iemand's portefeuille, een stemming teweeg brengen, of ondertekend worden door een groep personen. Door deze verstrengelingen lijkt een raadsvergadering meer op een spinnenweb dan een hiërarchische boomstructuur.
 
-# Hoe verhoudt ORI-A zich tot ORI?
+# Hoe verhoudt ORI•A zich tot ORI?
 
 ORI-A is gebaseerd op het informatiemodel dat is ontworpen voor de [Open Raadsinformatie (ORI) API](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie). Dit informatiemodel is aangepast aan de behoeftes van archieven. ORI-A biedt bijvoorbeeld geen ruimte voor gegevens over informatieobjecten, maar verwijst op die momenten naar MDTO. Ook zijn sommige verplichtingen verschillend. Een volledige lijst van de verschillen wordt nog opgemaakt.
 
@@ -56,7 +58,7 @@ Meer achtergrondinformatie over ORI kun je vinden op [de website van de ontwikke
 
 <!-- todo: benoem conversiescripts wanneer die af zijn -->
 
-# Voor wie is ORI-A bedoeld? 
+# Voor wie is ORI•A bedoeld? 
 
 ORI-A is bedoeld voor iedereen die betrokken is bij de duurzame toegankelijkheid van raadsinformatie. In het bijzonder:
 
@@ -66,7 +68,7 @@ ORI-A is bedoeld voor iedereen die betrokken is bij de duurzame toegankelijkheid
 
 Ten slotte kan ORI-A ook dienen als naslagwerk voor iedereen die gebruik wil maken van door overheden gepubliceerde ORI-A metagegevens. Denk bijvoorbeeld aan applicatiebouwers die viewers of zoekmachines voor (openbare) raadsinformatie willen ontwikkelen.
 
-# Wanneer gebruik je ORI-A? 
+# Wanneer gebruik je ORI•A? 
 
 ORI-A is toepasbaar in verschillende scenario’s:
 

--- a/pages/faq.md
+++ b/pages/faq.md
@@ -35,9 +35,9 @@ Toch waren er enkele redenen waarom een speciale archiefvariant van ORI nodig bl
   **Tip:** Je kunt meer lezen over het combineren van ORI-A en MDTO in [Hoe werkt ORI-A?](tutorial#mdto)
   :::
 
-* **Achterwaartse compatibiliteit (_backwards compatibility_).**  Bestaande raadsinformatie voldoet niet altijd aan alle eisen van ORI. Uit analyses van RIS systemen kwam bijvoorbeeld naar voren dat ORI soms gegevens vereist die ofwel niet beschikbaar zijn, ofwel niet beschikbaar zijn in de gevraagde vorm. Dit komt vooral voor bij **oudere vergaderingen**. Omdat ook deze vergaderingen gearchiveerd moeten worden, is ORI-A op bepaalde punten flexibeler (zie ook [Hoe verhoudt ORI-A zich tot ORI](faq#hoe-verhoudt-ori-a-zich-tot-ori)).
+* **Achterwaartse compatibiliteit (_backwards compatibility_).**  Bestaande raadsinformatie voldoet niet altijd aan alle eisen van het ORI-informatiemodel. Uit analyses van RIS-systemen kwam bijvoorbeeld naar voren dat ORI soms gegevens vereist die ofwel niet beschikbaar zijn, ofwel niet beschikbaar zijn in de gevraagde vorm. Dit komt vooral voor bij **oudere vergaderingen**. Omdat ook deze vergaderingen gearchiveerd moeten worden, is ORI-A op bepaalde punten flexibeler (zie ook [Hoe verhoudt ORI-A zich tot ORI](faq#hoe-verhoudt-ori-a-zich-tot-ori)).
 
-* **Duurzame toegankelijkheid.** Sommige gegevens in ORI, zoals de datum waarop een vergadering gehouden is, zijn essentieel voor de toekomstige interpreteerbaarheid van raadsinformatie, maar niet verplicht. Om de [duurzame toegankelijkheid](https://www.nationaalarchief.nl/archiveren/kennisbank/duurzaam-toegankelijk) van raadsinformatie te waarborgen zijn zulke gegevens in ORI-A wél verplicht gesteld.
+* **Duurzame toegankelijkheid.** Sommige gegevens in ORI, zoals de datum waarop een vergadering gehouden is, zijn essentieel voor de toekomstige interpreteerbaarheid van raadsinformatie, maar niet verplicht in het ORI-informatiemodel. Om de [duurzame toegankelijkheid](https://www.nationaalarchief.nl/archiveren/kennisbank/duurzaam-toegankelijk) van raadsinformatie te waarborgen zijn zulke gegevens in ORI-A wél verplicht gesteld.
 
 # Waarom heeft ORI•A geen aggregatieniveaus?
 
@@ -50,7 +50,7 @@ De hoofdreden voor deze relatief platte structuur is dat entiteiten in het  oors
 
 ORI-A is gebaseerd op het informatiemodel dat is ontworpen voor de [Open Raadsinformatie (ORI) API](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie). Dit informatiemodel is aangepast aan de behoeftes van archieven. ORI-A biedt bijvoorbeeld geen ruimte voor gegevens over informatieobjecten, maar verwijst op die momenten naar MDTO. Ook zijn sommige verplichtingen verschillend. Een volledige lijst van de verschillen wordt nog opgemaakt.
 
-Ondanks deze kleine aanpassingen is wel geprobeerd ORI-A **interoperabel** te houden met ORI. Formeler gezegd: je kan ORI zonder informatieverlies converteren naar een combinatie van ORI-A en MDTO (zie ook [round-trip format conversion](https://en.wikipedia.org/wiki/Round-trip_format_conversion)). De andere kant op (ORI-A + MDTO → ORI) kan ook, maar dan treed mogelijk informatieverlies op, aangezien ORI-A + MDTO een _superset_ is van ORI.
+Ondanks deze kleine aanpassingen is wel geprobeerd ORI-A **interoperabel** te houden met ORI. Formeler gezegd: je kan ORI zonder informatieverlies converteren naar een combinatie van ORI-A en MDTO (zie ook [round-trip format conversion](https://en.wikipedia.org/wiki/Round-trip_format_conversion)). De andere kant op (ORI-A + MDTO → ORI) kan ook, maar dan treedt mogelijk informatieverlies op, aangezien ORI-A + MDTO een _superset_ is van ORI.
 
 ::: waarschuwing
 Meer achtergrondinformatie over ORI kun je vinden op [de website van de ontwikkelaars van openbesluitvorming.nl](https://ontola.io/nl/cases/openbesluitvorming/) en [de website van openstate.eu](https://openstate.eu/nl/projecten-tools-data/besluiten/open-raadsinformatie/).
@@ -66,7 +66,7 @@ ORI-A is bedoeld voor iedereen die betrokken is bij de duurzame toegankelijkheid
 - Leveranciers die hun producten of diensten willen afstemmen op de behoeften vanuit de overheid.
 - Beheerders van raadsinformatiesystemen en andere functionarissen die betrokken zijn bij het migreren van raadsinformatie richting een e-depot. 
 
-Ten slotte kan ORI-A ook dienen als naslagwerk voor iedereen die gebruik wil maken van door overheden gepubliceerde ORI-A metagegevens. Denk bijvoorbeeld aan applicatiebouwers die viewers of zoekmachines voor (openbare) raadsinformatie willen ontwikkelen.
+Tenslotte kan ORI-A ook dienen als naslagwerk voor iedereen die gebruik wil maken van door overheden gepubliceerde ORI-A metagegevens. Denk bijvoorbeeld aan applicatiebouwers die viewers of zoekmachines voor (openbare) raadsinformatie willen ontwikkelen.
 
 # Wanneer gebruik je ORI•A? 
 

--- a/pages/over-ori-a.md
+++ b/pages/over-ori-a.md
@@ -9,29 +9,29 @@ position: 1
 
 # Wat is ORI•A?
 
-De Open Raadsinformatie Archiefstandaard (ORI-A) beschrijft de regels voor het duurzaam bewaren van raadsinformatie in XML-formaat. Dit XML-formaat kan gebruikt worden wanneer raadsinformatie, zoals een collectie videotulen, voor permanente bewaring naar een [e-depot](https://www.nationaalarchief.nl/archiveren/kennisbank/wat-is-een-e-depot) wordt gemigreerd. 
+De Open Raadsinformatie Archiefstandaard (ORI-A) beschrijft de regels voor het duurzaam bewaren en uitwisselen van raadsinformatie in XML-formaat. Hiervoor is het ORI-A XML-schema ontwikkeld, dat gebruikt kan worden wanneer raadsinformatie, zoals een collectie videotulen, voor permanente bewaring naar een [e-depot](https://www.nationaalarchief.nl/archiveren/kennisbank/wat-is-een-e-depot) wordt gemigreerd. 
 
-ORI-A is gebaseerd op het informatiemodel onder [de VNG's Open Raadsinformatie (ORI) API specificatie](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie). 
+ORI-A is gebaseerd op het informatiemodel van [de Open Raadsinformatie (ORI) API Specificatie](https://github.com/VNG-Realisatie/ODS-Open-Raadsinformatie). Op de rest van de website wordt dit het ORI-informatiemodel of ORI genoemd.
 
 ## Achtergrond
 
-Vanuit enkele archiefdiensten is de behoefte ontstaan om te komen tot een standaard voor het duurzaam bewaren en beschikbaarstellen van raadsinformatie in een digitale archiefbewaarplaats (het e-depot). Deze archiefdiensten hebben zich verenigd in de [Werkgroep Archivering Raadsinformatie](colofon).
+In de zomer van 2021 is tijdens een landelijke ['videotulenbijeenkomst'](https://kiacommunity.nl/thoughts/11904) door diverse stakeholders in het informatiedomein de wens uitgesproken om te komen tot een standaard voor de duurzame toegankelijkheid van raadsinformatie. De toen opgerichte [Werkgroep Archivering Raadsinformatie](colofon) kreeg de taak om deze standaard te realiseren. ORI-A is daarvan het resultaat.
 
-De werkgroep heeft twee doelen: het ontwikkelen, testen en gebruiksklaar maken van een ORI-A XML validatie schema ([XSD](https://en.wikipedia.org/wiki/XML_Schema_(W3C))), en vervolgens het gebruik van de standaard aanmoedigen en ondersteunen.
+De werkgroep heeft zich drie doelen gesteld: ten eerste het ontwikkelen, testen en gebruiksklaar maken van een ORI-A XML-schema ([XSD](https://en.wikipedia.org/wiki/XML_Schema_(W3C))), ten tweede het promoten en tijdelijk ondersteunen van het gebruik van de standaard, en ten derde het bestuurlijk laten vaststellen van het gebruik van de standaard en het borgen van het beheer op de lange termijn.
 
 ## Status
 
-De ORI-A XSD is momenteel in bèta, en [kan hier gedownload worden](https://github.com/Regionaal-Archief-Rivierenland/ORI-XSD/releases). De standaard is de afgelopen tijd getest aan enkele praktijkcases, momenteel wordt gewerkt aan de documentatie en voorbeeldbestanden. Vanaf het najaar volgen enkele pilotimplementaties, waarin de standaard wordt ingezet in de praktijk. Hierover zullen periodiek berichten op [KIA](https://kiacommunity.nl/welcome) verschijnen.
+Het ORI-A XML-schema is momenteel in bèta, en [kan hier gedownload worden](https://github.com/Regionaal-Archief-Rivierenland/ORI-XSD/releases). De standaard is de afgelopen tijd getest aan enkele praktijkcases, momenteel wordt gewerkt aan de documentatie en voorbeeldbestanden. Vanaf het najaar volgen enkele pilotimplementaties, waarin de standaard wordt ingezet in de praktijk. Hierover zullen periodiek berichten op [KIA](https://kiacommunity.nl/welcome) verschijnen.
 
 # Waarom is ORI•A ontwikkeld?
 
-ORI-A heeft een vergelijkbaar doel als het ORI-project geleid door de VNG: het gestandaardiseerd beschikbaar stellen van raadsinformatie. Deze standaardisatieslag is hard nodig, omdat ieder RIS-systeem momenteel een eigen, niet-publiekelijk gedocumenteerd formaat voor raadsinformatie hanteert. Hiermee komt de toekomstige **vindbaarheid** en **interpreteerbaarheid** van raadsinformatie in gevaar.
+ORI-A deelt het doel van de diverse ORI-initiatieven: het gestandaardiseerd beschikbaar stellen van raadsinformatie. Deze standaardisatieslag is hard nodig, omdat ieder RIS-systeem momenteel een eigen, niet-publiekelijk gedocumenteerd formaat voor raadsinformatie hanteert. Hiermee komt de toekomstige **vindbaarheid** en **interpreteerbaarheid** van raadsinformatie in gevaar. 
 
-Toch kon VNG's ORI niet aan alle behoeften van archieven voldoen. Hierom is besloten een archiefvariant van ORI te ontwikkelen. Je kan hier meer over lezen in [Waarom een speciale archiefstandaard?](faq)
+Waar ORI-A verschilt van de andere initiatieven is dat het zich ook richt op het migreren van raadsinformatie. Met ORI-A kan raadsinformatie gestandaardiseerd in XML-formaat worden opgeslagen. Hierin is eerst gekeken naar het ORI-informatiemodel, maar deze kon niet aan alle behoeften van archiefdiensten voldoen. Toen is besloten een archiefvariant van ORI te ontwikkelen. Je kan hier meer over lezen in [Waarom een speciale archiefstandaard?](faq)
 
 # Documentatie
 
 <!-- todo: benoem downloads pagina, het plaatje, en de voor mensen bedoelde documentatie   -->
-De documentatie van de XSD is een work-in-progress. De betekenis van de verschillende (sub)elementen kan op dit moment achterhaald worden uit de waardes binnen de `<xs:documentation>` tags.
+De documentatie van het ORI-A XML-schema is een work-in-progress. De betekenis van de verschillende (sub)elementen kan op dit moment achterhaald worden uit de waardes binnen de `<xs:documentation>` tags.
 
 Bovendien bestaat er een [grafische representatie van het informatiemodel.](ORI-A-diagram.pdf)

--- a/pages/over-ori-a.md
+++ b/pages/over-ori-a.md
@@ -4,7 +4,7 @@ position: 1
 ---
 
 ::: waarschuwing
-**Disclaimer:** De ORI-A website en bijbehorende documentatie zijn nog in ontwikkeling. Hou er daarom rekening mee dat alle informatie op deze website onvolledig, onnauwkeurig of verouderd kan zijn.
+**Disclaimer:** De ORI-A website en bijbehorende documentatie zijn nog in ontwikkeling. Hou er daarom rekening mee dat de informatie op deze website onvolledig, onnauwkeurig of verouderd kan zijn.
 :::
 
 # Wat is ORI•A?
@@ -23,7 +23,7 @@ De werkgroep heeft twee doelen: het ontwikkelen, testen en gebruiksklaar maken v
 
 De ORI-A XSD is momenteel in bèta, en [kan hier gedownload worden](https://github.com/Regionaal-Archief-Rivierenland/ORI-XSD/releases). De standaard is de afgelopen tijd getest aan enkele praktijkcases, momenteel wordt gewerkt aan de documentatie en voorbeeldbestanden. Vanaf het najaar volgen enkele pilotimplementaties, waarin de standaard wordt ingezet in de praktijk. Hierover zullen periodiek berichten op [KIA](https://kiacommunity.nl/welcome) verschijnen.
 
-# Waarom is ORI-A ontwikkeld?
+# Waarom is ORI•A ontwikkeld?
 
 ORI-A heeft een vergelijkbaar doel als het ORI-project geleid door de VNG: het gestandaardiseerd beschikbaar stellen van raadsinformatie. Deze standaardisatieslag is hard nodig, omdat ieder RIS-systeem momenteel een eigen, niet-publiekelijk gedocumenteerd formaat voor raadsinformatie hanteert. Hiermee komt de toekomstige **vindbaarheid** en **interpreteerbaarheid** van raadsinformatie in gevaar.
 

--- a/pages/tutorial.md
+++ b/pages/tutorial.md
@@ -3,9 +3,10 @@ title: Hoe werkt ORI-A?
 position: 2
 ---
 
-# Een vergadering beschrijven
+Op deze pagina laten we stap voor stap zien uit welke verschillende onderdelen een ORI-A XML-bestand kan bestaan en hoe ze werken in XML.
 
-Het meest simpele ORI-A XML bestand bestaat uit een **vergadering** met een lijst **agendapunten**.
+# Een vergadering beschrijven
+Het meest simpele ORI-A XML-bestand bestaat uit een **vergadering** met een lijst **agendapunten**.
 
 ``` {=html}
 <article class="card">
@@ -97,7 +98,7 @@ We raden aan om in de verwijzing naar je begrippenlijst (`<verwijzingBegrippenli
 :::
 
 
-# Hoofd- en subagendapunten
+# Agendapunten en subagendapunten
 
 Het is mogelijk agendapunten op te splitsen in **subagendapunten**. Dit is vooral handig als je agendapunten wilt onderverdelen in rubrieken.
 
@@ -174,7 +175,7 @@ Veel RIS-systemen beschouwen rubrieken zoals "Beëdigingen en Benoemingen"  als 
 :::
 
 
-# Relaties tussen ORI-A entiteiten aanleggen
+# Relaties tussen ORI•A entiteiten aanleggen
 
 ORI-A kent naast vergaderingen en agendapunten een hoop andere entiteiten, zoals stemmingen, deelnemers en fracties (het [ORI-A diagram](downloads#diagram) geeft een volledig overzicht).
 
@@ -360,7 +361,7 @@ TODO
 
 <!-- misschien incl. interactieve video, waarin je ook even het verschil uitlegt tussen relatieve en absolute timestamps -->
 
-# ORI-A & MDTO combineren
+# ORI•A & MDTO combineren
 
 ORI-A laat het beschrijven van [informatieobjecten](https://www.nationaalarchief.nl/archiveren/mdto/informatieobject) (**vergaderstukken**, **mediabestanden**, etc.) over aan **MDTO**. Met andere woorden: ORI-A beschrijft domein*specifieke* gegevens --- raadsgegevens --- terwijl MDTO beperkt blijft tot meer generieke gegevens over documenten en bestanden, zoals hun aanmaakdatum en auteur.
 
@@ -368,7 +369,7 @@ ORI-A laat het beschrijven van [informatieobjecten](https://www.nationaalarchief
 De enige _inhoudelijke_ informatie over informatieobjecten die in ORI-A wordt opgenomen is `<informatieobjectType>`. Deze informatie overlapt met `<classificatie>` binnen MDTO.  Deze informatie mag alsnog in ORI-A worden opgenomen, omdat het soms wel degelijk domeinspecifieke informatie betreft.  Voor het begrijpen van een vergadering kan het bijvoorbeeld uitmaken of een document een motie, amendement, of voorstel is.
 :::
 
-## ORI-A → MDTO verwijzingen in XML vorm
+## ORI•A → MDTO verwijzingen in XML vorm
 
 Om ORI-A gegevens aan een MDTO informatieobject te koppelen, verwijs je naar het ID van een in MDTO opgesteld informatieobject  (zie ook [`verwijzingGegevens`](#verwijzing-gegevens)):
 

--- a/pages/tutorial.md
+++ b/pages/tutorial.md
@@ -31,8 +31,7 @@ Het meest simpele ORI-A XML-bestand bestaat uit een **vergadering** met een lijs
 </article>
 ```
 
-
-Neem bijvoorbeeld de vergadering hierboven, met de ietwat onoriginele titel 'Gemeenteraad'. In ORI-A XML zou je deze vergadering zo uitdrukken:
+Neem bijvoorbeeld de vergadering hierboven, met de simpele titel 'Gemeenteraad'. In ORI-A XML zou je deze vergadering zo uitdrukken:
 
 ``` xml
 <ORI-A>
@@ -61,11 +60,11 @@ Dit zegt:
 
 > Er was **30 november 2023** een vergadering genaamd 'Gemeenteraad' met **twee agendapunten**. Tijdens het agendapunt met volgnummer 1 kwam de vaststelling van de agenda aan bod, en bij het volgende agendapunt was er ruimte voor mededelingen.
 
-Een goed begin, maar nog niet super informatief.
+Een goed begin, maar nog niet heel informatief.
 
 # Begrippenlijsten gebruiken
 
-Meestal wil je ook nog weten _wie_ de vergadering heeft georganiseerd. In ORI-A doe je dit door een `<bestuurslaag>` aan je vergadering toe te voegen:
+Meestal wil je ook weten _wie_ de vergadering heeft georganiseerd. In ORI-A doe je dit door een `<bestuurslaag>` aan je vergadering toe te voegen:
 
 ``` xml
 <vergadering>

--- a/pages/tutorial.md
+++ b/pages/tutorial.md
@@ -83,20 +83,17 @@ Meestal wil je ook nog weten _wie_ de vergadering heeft georganiseerd. In ORI-A 
 </vergadering>
 ```
 
-
 Wat je binnen `<bestuurslaag>` ziet is een begrip uit een zogeheten **begrippenlijst**. Een begrippenlijst is een verzameling gerelateerde begrippen, waarin ieder begrip meestal een **korte uitleg** en eigen **identificatiecode** krijgt. In ORI-A wordt soms gevraagd een begrip uit zo'n elders gedefinieerde lijst te kiezen.  Hierboven is het gekozen begrip `Gemeente Leiden`, ook wel bekend onder de code `gm0546`.
 
 De oorsprong van dit begrip is een begrippenlijst beheerd door het [TOOI project](https://standaarden.overheid.nl/tooi/waardelijsten/), maar [ORI-A definieert zelf ook een aantal begrippenlijsten](begrippenlijsten). Tenslotte kun je ook besluiten om zelf een begrippenlijst te onderhouden (zie hiervoor [de richtlijnen van het Nationaal Archief](https://www.nationaalarchief.nl/archiveren/mdto/begripbegrippenlijst)).
 
-
 :::waarschuwing
-We raden aan om in de verwijzing naar je begrippenlijst (`<verwijzingBegrippenlijst>`) een URL bij `<verwijzingID>` in te vullen. Hiermee maak je je begrippen vindbaar en valideerbaar.
+We raden aan om in de verwijzing naar je begrippenlijst (`<verwijzingBegrippenlijst>`) bij `<verwijzingID>` een URL in te vullen. Hiermee maak je je begrippen vindbaar en valideerbaar.
 :::
 
 :::tip
 **Tip:** `<bestuurslaag>` is bedoeld voor de overheidslaag die verantwoordelijk was voor de vergadering. Het specifieke **gremium** (bijvoorbeeld "Commissie Ruimte & Wonen") kun je kwijt in `<georganiseerdDoorGremium>`.
 :::
-
 
 # Agendapunten en subagendapunten
 
@@ -174,7 +171,6 @@ Dan kun je dat zo in XML uitdrukken:
 Veel RIS-systemen beschouwen rubrieken zoals "Beëdigingen en Benoemingen"  als agendapunten, maar geven ze geen volgnummers. Hierom is in ORI-A de volgorde van de `<(sub)agendapunt>`-elementen leidend voor de volgorde van de agenda.
 :::
 
-
 # Relaties tussen ORI•A entiteiten aanleggen
 
 ORI-A kent naast vergaderingen en agendapunten een hoop andere entiteiten, zoals stemmingen, deelnemers en fracties (het [ORI-A diagram](downloads#diagram) geeft een volledig overzicht).
@@ -184,7 +180,7 @@ Deze entiteiten hebben doorgaans veel **relaties**, zowel onderling als met exte
 ## Voorbeeld: de relaties van een stemming
 
 <!-- todo: documenteer ook wanneer je nest? -->
-Het aanmaken van een relatie tussen twee entiteiten --- bijvoorbeeld een stemming en een agendapunt --- gaat via een **verwijzing**<!-- (tenminste, zolang de entiteit waarnaar verweze—n wordt in principe herhaaldelijk aangehaald zou kunnen worden) -->.
+Het leggen van een relatie tussen twee entiteiten --- bijvoorbeeld een stemming en een agendapunt --- gaat via een **verwijzing**<!-- (tenminste, zolang de entiteit waarnaar verweze—n wordt in principe herhaaldelijk aangehaald zou kunnen worden) -->.
 
 Om een relatie tot stand te brengen, heeft de entiteit waarnaar verwezen wordt een uniek ID nodig. Dit ID kan vervolgens in `<verwijzingID>` worden ingevuld:
 
@@ -209,9 +205,8 @@ Dit zegt:
 Voor een uitgebreide uitleg over het verwijzen **naar externe informatieobjecten** zoals besluitvormingsstukken, zie [ORI-A & MDTO combineren](hoe-werkt-ori-a#ori-a-mdto-combineren).
 
 :::waarschuwing
-De ORI-A XSD checkt of alle waardes van `<ID>`'s binnen een XML boom uniek zijn. Dit vermindert de kans op ambigue verwijzingen.
+Het ORI-A XML-schema checkt of alle waardes van `<ID>`'s binnen een XML-boom uniek zijn. Dit vermindert de kans op ambigue verwijzingen.
 :::
-
 
 :::tip
 **Tip:** Over de keuze voor dit verwijzingsmechanisme kun je meer lezen in [Waarom heeft ORI-A geen aggregatieniveaus?](faq)
@@ -262,7 +257,6 @@ In ORI-A kun je [persoonsgegevens](documentatie#natuurlijk-persoon-gegevens) ond
 
 ## Aanwezige deelnemer
 
-
 De meest gebruikelijke optie is om persoonsgegevens onder het `<isNatuurlijkPersoon>` element van een aanwezige deelnemer te zetten:
 
 ``` xml
@@ -284,7 +278,6 @@ De meest gebruikelijke optie is om persoonsgegevens onder het `<isNatuurlijkPers
 Dit zegt in essentie: 
 
 > Peter van der Velden (de burgemeester) was in deze vergadering aanwezig als voorzitter.
-
 
 ## Informatie over personen buiten een vergadering
 
@@ -324,9 +317,7 @@ MDTO vraagt een aantal gegevens onder `<betrokkene>`:
 * Binnen `<betrokkeneTypeRelatie>` moet het **type relatie** tussen de persoon en het stuk beschreven worden, middels een begrip uit een begrippenlijst. ORI-A definieert hiervoor de [begrippenlijst 'Betrokkene-vergaderstuk relaties'](begrippenlijsten#betrokkene-vergaderstuk-relaties).
 * Binnen `<betrokkeneActor>` worden de **naam en ID** van de betrokkene verwacht, bijvoorbeeld `Jan de Vries` en `persoon-076` om naar de ambtenaar uit het voorbeeld hierboven te verwijzen.
 
-
 Stel bijvoorbeeld dat je wilt vastleggen dat een betrokkene een **indiener** van een stuk was, dan kun je dat zo doen:
-
 
 ``` xml
 <MDTO>
@@ -353,7 +344,6 @@ Stel bijvoorbeeld dat je wilt vastleggen dat een betrokkene een **indiener** van
     </betrokkene>
     …
 ```
-
 
 # Spreekfragmenten
 
@@ -425,17 +415,15 @@ De verwijzing naar deze mediabron komt in ORI-A onder `<vergadering>`:
 
 In je MDTO kun je eventueel de  [begrippenlijst 'Mediabron types']( begrippenlijsten#mediabron-types)  onder `mdto:classificatie` invullen, om ook daar het soort mediabron nader te specificeren.
 
-
 ### Ondertitelbestanden
 
 Als je een video met een los ondertitelbestand hebt, is het meestal het makkelijkst om een **complex informatieobject** aan te maken --- oftewel, een informatieobject dat is samengesteld uit meerdere bestanden:
-
 
 ```bash
 Gemeenteraad.mp4
 Gemeenteraad.mdto.xml
 Gemeenteraad.mp4.bestand.mdto.xml
-Gemeenteraad.vtt.bestand.mdto.xml  # dit is het ondertitel bestand
+Gemeenteraad.vtt.bestand.mdto.xml  # dit is het ondertitelbestand
 ```
 
 In MDTO druk je dit zo uit:

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -30,7 +30,7 @@ Gegevens van alle entiteiten die onder het _root_-element `<ORI-A>` komen.
 Gegevens over de vergadering, zoals de startdatum en locatie. Een vergadering kan uit een of meer deelvergaderingen bestaan.
 
 ::: waarschuwing
-**Let op:**  Alhoewel `<isVastgelegdMiddels>` strikt genomen niet verplicht is, is een transcriptie of (audio)visueel verslag noodzakelijk voor de toekomstige interpreteerbaarheid van raadsvergaderingen. Alleen in _zeer_ zeldzame situaties, zoals een besloten vergadering zonder opnames, mag `<isVastgelegdMiddels>` ontbreken.
+**Let op:**  `<isVastgelegdMiddels>` is niet verplicht in ORI-A, omdat er soms geen opnamen worden gemaakt van een vergadering, bijvoorbeeld als deze besloten (geheim) is. In alle andere gevallen raden we echter aan om via dit element altijd een transcriptie of (audio)visueel verslag op te nemen in de dataset.
 :::
 
 {{ vergadering_table }}

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -4,14 +4,12 @@ title: Het XML-schema
 position: 3
 ---
 
+Op deze pagina worden de verschillende onderdelen van het ORI-A XML-schema uitgelegd. Deze onderdelen zijn ook terug te zien op de [ORI-A UML diagram](https://ori-a.nl/ORI-A-diagram.pdf).
+<!-- todo: misschien een soort legenda van hoe deze pagina gelezen dient te worden? -->
+
 # Entiteiten
 
-<!-- todo: misschien een soort legenda van hoe deze pagina gelezen dient te worden? -->
-Datatypes van alle hoofdentiteiten in ORI-A.
-
-## ORI-A
-
-Gegevens die onder het _root_-element `<ORI-A>` komen.
+Gegevens van alle entiteiten die onder het _root_-element `<ORI-A>` komen.
 
 {{ ori_a_table }}
 
@@ -28,6 +26,8 @@ Gegevens die onder het _root_-element `<ORI-A>` komen.
 ```
 
 ## Vergadering
+
+Gegevens over de vergadering, zoals de startdatum en locatie. Een vergadering kan uit een of meer deelvergaderingen bestaan.
 
 ::: waarschuwing
 **Let op:**  Alhoewel `<isVastgelegdMiddels>` strikt genomen niet verplicht is, is een transcriptie of (audio)visueel verslag noodzakelijk voor de toekomstige interpreteerbaarheid van raadsvergaderingen. Alleen in _zeer_ zeldzame situaties, zoals een besloten vergadering zonder opnames, mag `<isVastgelegdMiddels>` ontbreken.
@@ -58,7 +58,8 @@ Gegevens die onder het _root_-element `<ORI-A>` komen.
 
 ## Agendapunt
 
-Gegevens over een agendapunt wat tijdens de vergadering behandeld is, zoals het volgnummer en bijbehorende stukken. De volgorde van agendapunt-elementen geeft aan in welke volgorde ze behandeld zijn.
+Gegevens over een agendapunt wat tijdens de vergadering behandeld is, zoals het volgnummer en bijbehorende stukken. Een agendapunt kan uit een of meer subagendapunten bestaan. 
+De volgorde van agendapunt-elementen geeft aan in welke volgorde ze behandeld zijn.
 
 {{ agendapunt_table }}
 
@@ -76,8 +77,10 @@ Gegevens over een agendapunt wat tijdens de vergadering behandeld is, zoals het 
 
 ## Stemming
 
+Gegevens over een stemming, zoals het agendapunt of de persoon waarover gestemd is.
+
 :::tip
-**Tip:** dit zijn gegevens over een **algemene stemming**; indivuele stemkeuzes komen onder [`aanwezigeDeelnemerGegevens`](#aanwezige-deelnemer).
+**Tip:** dit zijn gegevens over een **algemene stemming**; individuele stemkeuzes komen onder [`aanwezigeDeelnemerGegevens`](#aanwezige-deelnemer).
 :::
 
 {{ stemming_table }}
@@ -112,12 +115,16 @@ Gegevens over een agendapunt wat tijdens de vergadering behandeld is, zoals het 
 ```
 
 ## Besluit
+
+Gegevens over het besluit waartoe de stemming heeft geleid, zoals of het unaniem aangenomen of verworpen is.
+
 {{ besluit_table }}
 
 ## Fractie
 
-Bij `<bestuurslaag>` bij voorkeur een waarde uit een van de volgende TOOI begrippenlijsten opgeven:
+Gegevens over een fractie, zoals de naam en het stemgedrag van de fractie.
 
+Bij `<bestuurslaag>` bij voorkeur een waarde uit een van de volgende TOOI begrippenlijsten opgeven:
 
 * [Begrippenlijst Gemeentes](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
 * [Begrippenlijst Waterschappen](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
@@ -143,8 +150,9 @@ Bij `<bestuurslaag>` bij voorkeur een waarde uit een van de volgende TOOI begrip
 ```
 ## Dagelijks bestuur
 
-Bij `<bestuurslaag>` bij voorkeur een waarde uit een van de volgende TOOI begrippenlijsten opgeven:
+Gegevens over een dagelijks bestuur, zoals de naam van het bestuur.
 
+Bij `<bestuurslaag>` bij voorkeur een waarde uit een van de volgende TOOI begrippenlijsten opgeven:
 
 * [Begrippenlijst Gemeentes](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
 * [Begrippenlijst Waterschappen](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
@@ -159,10 +167,11 @@ Bij `<bestuurslaag>` bij voorkeur een waarde uit een van de volgende TOOI begrip
 </todo>
 ```
 
+## Persoon buiten vergadering
 
-## Natuurlijk persoon
+Gegevens over een persoon die een relatie heeft met de vergadering, maar niet zelf aanwezig was. Dit kan bijvoorbeeld een portefeuillehouder, indiender of afwezig raadslid zijn.
 
-Dit datatype komt voor onder `<aanwezigeDeelnemer>` en  het top-level element `<persoonBuitenVergadering>`
+Het datatype van deze entiteit komt ook voor onder `<aanwezigeDeelnemer>`. Zie voor uitleg hierover de rubriek [Persoonsgegevens](https://ori-a.nl/tutorial#persoonsgegevens).
 
 Een belangrijke toepassing van dit datatype is vastleggen wie lid is van welke fractie. Dit kan via het `<isLidVanFractie>` element (zie XML voorbeeld).
 
@@ -176,6 +185,8 @@ Een belangrijke toepassing van dit datatype is vastleggen wie lid is van welke f
 
 ## Aanwezige deelnemer
 
+Gegevens over een persoon die daadwerkelijk bij de vergadering aanwezig was, zoals diens stemgedrag, inspreekmomenten, en meer algemene persoonsgegevens.
+
 {{ aanwezige_deelnemer_table }}
 
 ### XML voorbeeld
@@ -185,7 +196,7 @@ Een belangrijke toepassing van dit datatype is vastleggen wie lid is van welke f
     <rolnaam>Voorzitter</rolnaam>
     <isNatuurlijkPersoon>
         <ID>0028-08a0</ID>
-        <functie>Burgermeester</functie>
+        <functie>Burgemeester</functie>
         <naam>
             <achternaam>Veltman</achternaam>
             <volledigeNaam>Julia</volledigeNaam>
@@ -215,7 +226,7 @@ Een belangrijke toepassing van dit datatype is vastleggen wie lid is van welke f
 
 # Gegevensgroepen
 
-Gegevensgroepen (<span class="badge">G</span>) komen altijd direct onder een ander element, en krijgen nooit een ID.
+Gegevensgroepen (<span class="badge">G</span>) bevatten een aantal gegevens die bij inhoudelijk elkaar horen. Ze komen in ORI-A altijd direct onder een ander element, en krijgen nooit een ID.
 
 ## Naam
 
@@ -232,6 +243,8 @@ Gegevens over de naam van een natuurlijk persoon.
 
 ## Stemming over personen
 
+Gegevens die het het resultaat van een stemming over personen beschrijven, zoals het aantal stemmen wat een persoon haalde.
+
 {{ stemming_over_personen_table }}
 
 ### XML voorbeeld
@@ -242,6 +255,8 @@ Gegevens over de naam van een natuurlijk persoon.
 ```
 
 ## Nevenfunctie
+
+Gegevens over nevenfuncties van de persoon, zoals of het om een betaalde functie gaat.
 
 {{ nevenfunctie_table }}
 
@@ -256,6 +271,7 @@ Gegevens over de naam van een natuurlijk persoon.
 
 ## Fractielidmaatschap
 
+Gegevens over wanneer iemand lid is geworden van welke fractie.
 
 {{ fractielidmaatschap_table }}
 
@@ -267,6 +283,7 @@ Gegevens over de naam van een natuurlijk persoon.
 
 ## Dagelijks bestuur lidmaatschap
 
+Gegevens over wanneer iemand lid is geworden van welk dagelijks bestuur.
 
 {{ dagelijks_bestuur_lidmaatschap_table }}
 
@@ -278,6 +295,7 @@ Gegevens over de naam van een natuurlijk persoon.
 
 ## Spreekfragment
 
+Gegevens over een spreekfragment waarin de deelnemer sprak, zoals het moment waarop dit fragment begon en eindigde.
 {{ spreekfragment_table }}
 
 ## Stem

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -33,7 +33,6 @@ Gegevens over de vergadering, zoals de startdatum en locatie. Een vergadering ka
 **Let op:**  Alhoewel `<isVastgelegdMiddels>` strikt genomen niet verplicht is, is een transcriptie of (audio)visueel verslag noodzakelijk voor de toekomstige interpreteerbaarheid van raadsvergaderingen. Alleen in _zeer_ zeldzame situaties, zoals een besloten vergadering zonder opnames, mag `<isVastgelegdMiddels>` ontbreken.
 :::
 
-
 {{ vergadering_table }}
 
 <!-- misschien deze uitklapbaar maken -->
@@ -62,7 +61,6 @@ Gegevens over een agendapunt wat tijdens de vergadering behandeld is, zoals het 
 De volgorde van agendapunt-elementen geeft aan in welke volgorde ze behandeld zijn.
 
 {{ agendapunt_table }}
-
 
 ### XML voorbeeld
 
@@ -130,7 +128,6 @@ Bij `<bestuurslaag>` bij voorkeur een waarde uit een van de volgende TOOI begrip
 * [Begrippenlijst Waterschappen](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
 * [Begrippenlijst Provincie](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
 
-
 {{ fractie_table }}
 
 ### XML voorbeeld
@@ -157,7 +154,6 @@ Bij `<bestuurslaag>` bij voorkeur een waarde uit een van de volgende TOOI begrip
 * [Begrippenlijst Gemeentes](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
 * [Begrippenlijst Waterschappen](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
 * [Begrippenlijst Provincie](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
-
 
 {{ dagelijks_bestuur_table }}
 
@@ -218,12 +214,6 @@ Gegevens over een persoon die daadwerkelijk bij de vergadering aanwezig was, zoa
     ...
 ```
 
-
-
-
-
-
-
 # Gegevensgroepen
 
 Gegevensgroepen (<span class="badge">G</span>) bevatten een aantal gegevens die bij inhoudelijk elkaar horen. Ze komen in ORI-A altijd direct onder een ander element, en krijgen nooit een ID.
@@ -235,7 +225,6 @@ Gegevens over de naam van een natuurlijk persoon.
 {{ naam_table }}
 
 ### XML voorbeeld
-
 
 ``` xml
 </todo>
@@ -249,7 +238,6 @@ Gegevens die het het resultaat van een stemming over personen beschrijven, zoals
 
 ### XML voorbeeld
 
-
 ``` xml
 </todo>
 ```
@@ -261,7 +249,6 @@ Gegevens over nevenfuncties van de persoon, zoals of het om een betaalde functie
 {{ nevenfunctie_table }}
 
 ### XML voorbeeld
-
 
 ``` xml
 </todo>
@@ -296,6 +283,7 @@ Gegevens over wanneer iemand lid is geworden van welk dagelijks bestuur.
 ## Spreekfragment
 
 Gegevens over een spreekfragment waarin de deelnemer sprak, zoals het moment waarop dit fragment begon en eindigde.
+
 {{ spreekfragment_table }}
 
 ## Stem


### PR DESCRIPTION
het uniformeren van alle headers op de pagina's (taalgebruik, uitleg van betekenis) en toevoegen van een regel uitleg bovenaan de pagina's van de bedoeling van die pagina