### PR TITLE
xml-schema: introtekst aanpassingen

### DIFF
--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -7,7 +7,7 @@ position: 3
 
 Op deze pagina vindt je de formele specificaties van alle onderdelen van het ORI-A XML-schema. Deze onderdelen kun je ook terugvinden in het [ORI-A UML diagram](https://ori-a.nl/ORI-A-diagram.pdf).
 
-De inhoud van deze pagina wordt automatisch gegeneerd op basis van het XML-schema, en is dus altijd up-to-date.
+De inhoud van deze pagina wordt automatisch gegenereerd op basis van het XML-schema, en is dus altijd up-to-date.
 
 # Entiteiten
 

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -5,7 +5,9 @@ title-icon: </>
 position: 3
 ---
 
-Op deze pagina worden de verschillende onderdelen van het ORI-A XML-schema uitgelegd. Deze onderdelen zijn ook terug te zien op de [ORI-A UML diagram](https://ori-a.nl/ORI-A-diagram.pdf).
+Op deze pagina vindt je de formele specificaties van alle onderdelen van het ORI-A XML-schema. Deze onderdelen kun je ook terugvinden in het [ORI-A UML diagram](https://ori-a.nl/ORI-A-diagram.pdf).
+
+De inhoud van deze pagina wordt automatisch gegeneerd op basis van het XML-schema, en is dus altijd up-to-date.
 
 # Entiteiten
 


### PR DESCRIPTION
```diff
- Op deze pagina worden de verschillende onderdelen van het ORI-A XML-schema uitgelegd.
+ Op deze pagina vindt je de formele specificaties van alle onderdelen van het ORI-A XML-schema.
```

Uitleggen lijkt mij niet het meest passende werkwoord hier, en bovendien  verwarrend nu er een pagina "ORI-A XML uitgelegd" bestaat. Het doel is echt een vrij saaie kopie van de XSD te zijn, niet om daar nog een keer uitleg over te geven. 

```diff
+ De inhoud van deze pagina wordt automatisch gegenereerd op basis van het XML-schema, en is dus altijd up-to-date.
```

Ik twijfel opeens of dit meerwaarde heeft om expliciet te noemen. Misschien is het wel geruststellend om te weten dat deze documentatie een accurate reflectie is van de XSD, tho. Voor onze werkgroep zou het ook wel nuttig zijn geweest dit te weten, want "foutjes" op deze pagina zijn dus eigenlijk bijna altijd afkomstig uit XSD, ipv de website repo.   