### PR TITLE
Updatexmlschema - XML voorbeelden en dubbele tekst

### DIFF
--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -33,7 +33,7 @@ Gegevens die onder het _root_-element `<ORI-A>` komen.
 ## Vergadering
 
 ::: waarschuwing
-**Let op:** `<isVastgelegdMiddels>` is niet verplicht in ORI-A, omdat er soms geen opnamen worden gemaakt van een vergadering, bijvoorbeeld als deze besloten (geheim) is. In alle andere gevallen raden we echter aan om via dit element altijd een transcriptie of (audio)visueel verslag op te nemen in de dataset.
+**Let op:**  Alhoewel `<isVastgelegdMiddels>` strikt genomen niet verplicht is, is een transcriptie of (audio)visueel verslag noodzakelijk voor de toekomstige interpreteerbaarheid van raadsvergaderingen. Alleen in _zeer_ zeldzame situaties, zoals een besloten vergadering zonder opnames, mag `<isVastgelegdMiddels>` ontbreken.
 :::
 
 

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -275,7 +275,11 @@ Gegevens over de naam van een natuurlijk persoon.
 
 
 ``` xml
-</todo>
+<nevenfunctie>
+    <omschrijving>Promovendus</omschrijving>
+    <naamOrganisatie>Universiteit Leiden</naamOrganisatie>
+    <bezoldigd>true</bezoldigd>
+</nevenfunctie>
 ```
 
 # Relatieklasses

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -143,7 +143,19 @@ Gegevens over een agendapunt wat tijdens de vergadering behandeld is, zoals het 
 ### XML voorbeeld
 
 ``` xml
-</todo>
+    <dagelijksBestuur>
+        <ID>College van B&W-gm0546</ID>
+        <dagelijksBestuurNaam>College van B&W</dagelijksBestuurNaam>
+        <dagelijksBestuurType>College</dagelijksBestuurType>
+        <bestuurslaag>
+            <begripLabel>Gemeente Leiden</begripLabel>
+            <begripCode>gm0546</begripCode>
+            <verwijzingBegrippenlijst>
+                <verwijzingID>https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4</verwijzingID>
+                <verwijzingNaam>TOOI Register gemeenten compleet</verwijzingNaam>
+            </verwijzingBegrippenlijst>
+        </bestuurslaag>
+    </dagelijksBestuur>
 ```
 
 

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -292,7 +292,12 @@ Gegevens over de naam van een natuurlijk persoon.
 ### XML voorbeeld
 
 ``` xml
-</todo>
+<isLidVanFractie>
+    <voorzitter>true</voorzitter>
+    <verwijzingFractie>
+        <verwijzingID>D66-gm0826</verwijzingID>
+    </verwijzingFractie>
+</isLidVanFractie>
 ```
 
 ## Dagelijks bestuur lidmaatschap

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -170,7 +170,26 @@ Een belangrijke toepassing van dit datatype is vastleggen wie lid is van welke f
 ### XML voorbeeld
 
 ``` xml
-</todo>
+<isNatuurlijkPersoon>
+            <ID>Persoon-1</ID>
+            <geslachtsaanduiding>Man</geslachtsaanduiding>
+            <functie>Raadslid</functie>
+            <naam>
+                <achternaam>de Boer</achternaam>
+                <volledigeNaam>Peter de Boer</volledigeNaam>
+            </naam>
+            <nevenfunctie>
+                <omschrijving>Promovendus</omschrijving>
+                <naamOrganisatie>Universiteit Leiden</naamOrganisatie>
+                <bezoldigd>true</bezoldigd>
+            </nevenfunctie>
+            <isLidVanFractie>
+                <voorzitter>true</voorzitter>
+                <verwijzingFractie>
+                    <verwijzingID>D66-gm0826</verwijzingID>
+                </verwijzingFractie>
+            </isLidVanFractie>
+        </isNatuurlijkPersoon>
 ```
 
 ## Aanwezige deelnemer

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -33,7 +33,7 @@ Gegevens die onder het _root_-element `<ORI-A>` komen.
 ## Vergadering
 
 ::: waarschuwing
-**Let op:** `<isVastgelegdMiddels>` is niet verplicht in ORI-A, omdat er soms geen opnamen worden gemaakt van een vergadering, bijvoorbeeld als deze besloten (geheim) is. In alle andere gevallen raden we echter aan om via dit element altijd een transcriptie of (audio)visueel verslag op te nemen in de dataset.
+**Let op:** `<isVastgelegdMiddels>` is niet verplicht in ORI-A, omdat er soms geen opnamen worden gemaakt van een vergadering, bijvoorbeeld als deze besloten is. In alle andere gevallen raden we echter aan om via dit element een transcriptie of (audio)visueel verslag op te nemen.
 :::
 
 

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -119,14 +119,6 @@ Gegevens over een agendapunt wat tijdens de vergadering behandeld is, zoals het 
 
 ## Fractie
 
-Bij `<bestuurslaag>` bij voorkeur een waarde uit een van de volgende TOOI begrippenlijsten opgeven:
-
-
-* [Begrippenlijst Gemeentes](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
-* [Begrippenlijst Waterschappen](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
-* [Begrippenlijst Provincie](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
-
-
 {{ fractie_table }}
 
 ### XML voorbeeld
@@ -145,14 +137,6 @@ Bij `<bestuurslaag>` bij voorkeur een waarde uit een van de volgende TOOI begrip
 </fractie>
 ```
 ## Dagelijks bestuur
-
-Bij `<bestuurslaag>` bij voorkeur een waarde uit een van de volgende TOOI begrippenlijsten opgeven:
-
-
-* [Begrippenlijst Gemeentes](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
-* [Begrippenlijst Waterschappen](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
-* [Begrippenlijst Provincie](https://identifier.overheid.nl/tooi/set/rwc_gemeenten_compleet/4)
-
 
 {{ dagelijks_bestuur_table }}
 
@@ -270,12 +254,26 @@ Gegevens over de naam van een natuurlijk persoon.
 ### XML voorbeeld
 
 ``` xml
-</todo>
+<isLidVanDagelijksBestuur>
+    <datumBeginDagelijksBestuurLidmaatschap>2023-09-01</datumBeginDagelijksBestuurLidmaatschap>
+    <verwijzingDagelijksBestuur>
+        <verwijzingID>College van B&amp;W-gm0546</verwijzingID>
+    </verwijzingDagelijksBestuur>
+</isLidVanDagelijksBestuur>
 ```
 
 ## Spreekfragment
 
 {{ spreekfragment_table }}
+
+``` xml
+<spreektTijdensSpreekfragment>
+    <videoTijdsaanduidingAanvang>00:02:20</videoTijdsaanduidingAanvang>
+    <spreektTijdensAgendapunt>
+        <verwijzingID>2028a00aaa2a8aaa00a2aab6bdaef</verwijzingID>
+    </spreektTijdensAgendapunt>
+</spreektTijdensSpreekfragment>
+```
 
 ## Stem
 
@@ -284,7 +282,12 @@ Gegevens over de naam van een natuurlijk persoon.
 ### XML voorbeeld
 
 ``` xml
-</todo>
+<neemtDeelAanStemming>
+            <keuzeStemming>Voor</keuzeStemming>
+            <gegevenOpStemming>
+                <verwijzingID>RV 23.0081</verwijzingID>
+            </gegevenOpStemming>
+        </neemtDeelAanStemming>
 ```
 
 ## Stemresultaat per fractie

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -239,7 +239,10 @@ Gegevens over de naam van een natuurlijk persoon.
 
 
 ``` xml
-</todo>
+<naam>
+    <achternaam>Veltman</achternaam>
+    <volledigeNaam>Julia</volledigeNaam>
+</naam>
 ```
 
 ## Stemming over personen

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -33,7 +33,7 @@ Gegevens die onder het _root_-element `<ORI-A>` komen.
 ## Vergadering
 
 ::: waarschuwing
-**Let op:**  Alhoewel `<isVastgelegdMiddels>` strikt genomen niet verplicht is, is een transcriptie of (audio)visueel verslag noodzakelijk voor de toekomstige interpreteerbaarheid van raadsvergaderingen. Alleen in _zeer_ zeldzame situaties, zoals een besloten vergadering zonder opnames, mag `<isVastgelegdMiddels>` ontbreken.
+**Let op:** `<isVastgelegdMiddels>` is niet verplicht in ORI-A, omdat er soms geen opnamen worden gemaakt van een vergadering, bijvoorbeeld als deze besloten (geheim) is. In alle andere gevallen raden we echter aan om via dit element altijd een transcriptie of (audio)visueel verslag op te nemen in de dataset.
 :::
 
 

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -253,7 +253,18 @@ Gegevens over de naam van een natuurlijk persoon.
 
 
 ``` xml
-</todo>
+<stemming>
+    <ID>stemming-0011</ID>
+    <resultaatStemmingOverPersonen>Maria Zeeger is verkozen als commissielid Ruimte en Wonen</resultaatStemmingOverPersonen>
+    <stemmingOverPersonen>
+        <naamKandidaat>Willem Wouters</naamKandidaat>
+        <aantalUitgebrachteStemmenvolledigeNaam>2</aantalUitgebrachteStemmen>
+    <stemmingOverPersonen>
+        <naamKandidaat>Henk Meegenkamp</naamKandidaat>
+        <aantalUitgebrachteStemmenvolledigeNaam>4</aantalUitgebrachteStemmen>
+    <stemmingOverPersonen>
+        <naamKandidaat>Maria Zeeger</naamKandidaat>
+        <aantalUitgebrachteStemmenvolledigeNaam>6</aantalUitgebrachteStemmen>
 ```
 
 ## Nevenfunctie

--- a/pages/xml-schema.md.j2
+++ b/pages/xml-schema.md.j2
@@ -33,7 +33,7 @@ Gegevens die onder het _root_-element `<ORI-A>` komen.
 ## Vergadering
 
 ::: waarschuwing
-**Let op:** `<isVastgelegdMiddels>` is niet verplicht in ORI-A, omdat er soms geen opnamen worden gemaakt van een vergadering, bijvoorbeeld als deze besloten is. In alle andere gevallen raden we echter aan om via dit element een transcriptie of (audio)visueel verslag op te nemen.
+**Let op:** `<isVastgelegdMiddels>` is niet verplicht in ORI-A, omdat er soms geen opnamen worden gemaakt van een vergadering, bijvoorbeeld als deze besloten (geheim) is. In alle andere gevallen raden we echter aan om via dit element altijd een transcriptie of (audio)visueel verslag op te nemen in de dataset.
 :::
 
 


### PR DESCRIPTION
aanpassingen aan de XML schema pagina:
 - verwijderen van twee blokken met voorbeelden voor `<bestuurslaag>`, omdat die al vaker voorkomen (zie commit)
  - XML-voorbeelden voor de XML-elementen waarbij deze nog ontbraken

Daarnaast twee commits gerevert die over hetzelfde stukje tekst gingen, omdat die nog op de branch stonden maar inmiddels in de main al waren aangepast.