### PR TITLE
begrippenlijsten: voeg tip toe over de optie om eigengemaakte lijsten te gebruiken

### DIFF
--- a/pages/begrippenlijsten.md
+++ b/pages/begrippenlijsten.md
@@ -27,6 +27,11 @@ Vanuit ORI-A XML kun je op volgende manier naar een begrippenlijst verwijzen (in
 
 Zie [Hoe werkt ORI-A?](hoe-werkt-ori-a#begrippenlijsten-gebruiken) voor een uitgebreider voorbeeld.
 
+::: tip
+**Tip:** Alhoewel we aanraden bestaande begrippenlijsten te gebruiken of [suggesties te doen om ze completer te maken](https://github.com/Regionaal-Archief-Rivierenland/ORI-A-Website/issues/new), kun je er ook voor kiezen zelf een begrippenlijsten te starten. Dit kan bijvoorbeeld nuttig zijn als een instantie unieke werkprocessen hanteert.
+
+Zorg in dat geval wel dat deze begrippenlijst [duurzaam wordt beheert](https://www.nationaalarchief.nl/archiveren/mdto/begripbegrippenlijst).
+:::
 
 # Vergaderstuktypes
 


### PR DESCRIPTION


Ik mistte dit een beetje in de introductie van deze pagina; nu zou je het misschien kunnen lezen als "je mag alleen begrippenlijsten van TOOI en ORI-A gebruiken". Vandaar een huishoudelijke mededeling.

Suggesties op de formulering, of compleet andere oplossingen zijn welkom. Ik ben bijvoorbeeld ook oke met het herschrijven van de pagina intro om duidelijker te maken dat je uit drie bronnen van begrippenlijsten kan kiezen (ORI-A, TOOI, en iets zelf gemaakts)

Op zich wordt dit ook al wel op andere plekken uitgelegd (zoals op https://ori-a.nl/begrippenlijsten#deelnemerrollen), maar omdat je deze pagina normaliter nooit van voor naar achter leest denk ik dat herhaling niet zo erg is.