### PR TITLE
begrippenlijsten: voeg resterende begrippenlijsten toe

### DIFF
--- a/pages/begrippenlijsten.md
+++ b/pages/begrippenlijsten.md
@@ -90,7 +90,7 @@ De onderstaande begrippenlijst kan binnen MDTO worden gebruikt om het soort rela
 | Ondertekenaar      | Ondertekenaar van een vergaderstuk.     |
 | Portefeuillehouder | De portefeuillehouder van een voorstel. |
 
-# Vergaderingstype
+# Vergaderingstypes
 
 Met de begrippen uit deze lijst kan het type van een [`<vergadering>`](xml-schema#vergadering) worden vastgelegd:
 
@@ -104,7 +104,7 @@ Met de begrippen uit deze lijst kan het type van een [`<vergadering>`](xml-schem
 | Algemene bestuursvergadering | Vergadering van een algemeen bestuur. |
 | Presidium                    | Vergadering van een presidium.        |
 
-# Dagelijks bestuur type
+# Dagelijks bestuur types
 
 Met de begrippen uit deze lijst kan het type van een [`<dagelijksBestuur>`](xml-schema#dagelijksBestuur) worden vastgelegd:
 
@@ -114,7 +114,7 @@ Met de begrippen uit deze lijst kan het type van een [`<dagelijksBestuur>`](xml-
 | Gedeputeerde Staten | Dagelijks bestuur van de provincie.   |
 | Dagelijks bestuur   | Dagelijks bestuur van een waterschap. |
 
-# Functie
+# Functies
 
 Met de begrippen uit deze lijst kan de functie of ambt van een persoon worden vastgelegd:
 

--- a/pages/begrippenlijsten.md
+++ b/pages/begrippenlijsten.md
@@ -90,6 +90,61 @@ De onderstaande begrippenlijst kan binnen MDTO worden gebruikt om het soort rela
 | Ondertekenaar      | Ondertekenaar van een vergaderstuk.     |
 | Portefeuillehouder | De portefeuillehouder van een voorstel. |
 
+# Vergaderingstype
+
+Met de begrippen uit deze lijst kan het type van een [`<vergadering>`](xml-schema#vergadering) worden vastgelegd:
+
+
+| Label                        | Definitie                             |
+|:-----------------------------|:--------------------------------------|
+| Raadsvergadering             | Vergadering van een gemeenteraad.     |
+| Commissievergadering         | Vergadering van een commissie.        |
+| Collegevergadering           | Vergadering van een college.          |
+| Statenvergadering            | Vergadering van Provinciale Staten.   |
+| Algemene bestuursvergadering | Vergadering van een algemeen bestuur. |
+| Presidium                    | Vergadering van een presidium.        |
+
+# Dagelijks bestuur type
+
+Met de begrippen uit deze lijst kan het type van een [`<dagelijksBestuur>`](xml-schema#dagelijksBestuur) worden vastgelegd:
+
+| Label               | Definitie                             |
+|:--------------------|:--------------------------------------|
+| College             | Dagelijks bestuur van een gemeente.   |
+| Gedeputeerde Staten | Dagelijks bestuur van de provincie.   |
+| Dagelijks bestuur   | Dagelijks bestuur van een waterschap. |
+
+# Functie
+
+Met de begrippen uit deze lijst kan de functie of ambt van een persoon worden vastgelegd:
+
+| Label                     | Definitie                                                        |
+|:--------------------------|:-----------------------------------------------------------------|
+| Burgemeester              | De burgemeester.                                                 |
+| Wethouder                 | Lid van het dagelijks bestuur van een gemeente.                  |
+| Raadslid                  | Gekozen volksvertegenwoordiger binnen een gemeente.              |
+| Burgerlid                 | Door de gemeenteraad benoemd lid van een commissie of werkgroep. |
+| Griffier                  | Hoofd van de griffie.                                            |
+| Gemeentesecretaris        | De secretaris van het college van B&W.                           |
+| Commissaris van de Koning | Commissaris van de Koning of Koningin.                           |
+| Gedeputeerde              | Lid van het dagelijks bestuur van een provincie.                 |
+| Statenlid                 | Lid van de Provinciale Staten.                                   |
+| Provinciesecretaris       | De secretaris van het college van Gedeputeerde Staten.           |
+| Dijkgraaf                 | Voorzitter van een waterschap.                                   |
+| Dagelijks bestuurslid     | Lid van een dagelijks bestuur.                                   |
+| Algemeen bestuurslid      | Lid van een algemeen bestuur.                                    |
+| Secretarisdirecteur       | Secretarisdirecteur van een waterschap.                          |
+| Ambtenaar/medewerker      | Een overheidsmedewerker.                                         |
+| Adviseur of deskundige    | Een door de overheid ingehuurde adviseur of deskundige.          |
+| <del>Overig</del>         | -                                                                |
+
+::: waarschuwing
+De functie "Overig" bestaat om compatibiliteit met het oorspronkelijke ORI informatiemodel te garanderen. Het gebruik van deze functieaanduiding wordt afgeraden. Als de bestaande functies niet toereikend zijn, heb je twee opties:
+
+* Een uitbreiding op deze begrippenlijst [aanvragen](https://github.com/Regionaal-Archief-Rivierenland/ORI-A-Website/issues/new)
+* Een nieuwe begrippenlijst starten
+:::
+
 # TOOI Begrippenlijsten
 
 Een paar begrippenlijsten die van toepassing zijn op ORI-A worden beheerd door TOOI. Dit betreft de begrippenlijsten voor het element `<bestuurslaag>`:


### PR DESCRIPTION
Bij de definities heb ik net als bij de andere begrippen meestal geprobeerd te focusen op "wanneer moet ik dit gebruiken" in plaats van bestuursrechtelijke of andere formele definities. De hoop is dat iedereen weet wat een burgemeester/commissaris van de koning is; als we dat diep gaan uitwerken, schieten we onszelf mogelijk alleen maar in voet (bovendien hebben we niet altijd de expertise in huis)

Een paar quircks zijn afkomstig uit de VNG documentatie. Specifieck deze:

>  College:              Dagelijks bestuur van een gemeente.
>  Gedeputeerde Staten:  Dagelijks bestuur van de provincie.
>  Dagelijks bestuur:    Dagelijks bestuur van een waterschap.

Je zou kunnen zeggen de laatste definitie generieker kan/moet (zoals in https://gitlab.com/koop/woo/aanleveren-ori/-/issues/45), maar ik denk juist dat dit element is bedoeld voor het preciezer specificeren van het type dagelijks bestuur. Deze begrippen zijn alleen van toepassing op iets waarvan je al weet dat het een dagelijksbestuur is, dus het feit dat je net iets specifiecker kan zijn is hier juist goed.

Het label is wel een beetje ongelukkig gekozen.

Sommige definities moeten mogelijk herzien worden afhankelijk van https://gitlab.com/koop/woo/aanleveren-ori/-/issues/45