### PR TITLE
begrippenlijsten: documenteer TOOI begrippenlijsten elders

### DIFF
--- a/pages/begrippenlijsten.md
+++ b/pages/begrippenlijsten.md
@@ -4,9 +4,11 @@ title-icon: lijst.svg
 position: 4
 ---
 
-Hier vind je een overzicht van alle begrippenlijsten die met ORI-A en raadsinformatie te maken hebben. Een begrippenlijst is een manier om gegevens te relateren aan een extern vastgestelde lijst van waarden. ORI-A volgt de definitie, semantiek en toepassing van begrippenlijsten zoals die ook in [MDTO](https://www.nationaalarchief.nl/archiveren/mdto/begripbegrippenlijst) worden gehanteerd.
+Hier vind je een overzicht van alle begrippenlijsten die door ORI-A worden beheerd en met raadsinformatie te maken hebben. Een begrippenlijst is een manier om gegevens te relateren aan een extern vastgestelde lijst van waarden. ORI-A volgt de definitie, semantiek en toepassing van begrippenlijsten zoals die ook in [MDTO](https://www.nationaalarchief.nl/archiveren/mdto/begripbegrippenlijst) worden gehanteerd.
 
-Waar mogelijk maakt ORI-A gebruik van begrippenlijsten van **TOOI**, [een standaardisatieproject opgezet door de Rijksoverheid](https://standaarden.overheid.nl/tooi/doc/tooi-registers/). In andere gevallen beheert ORI-A voorlopig eigen begrippenlijsten.
+Waar mogelijk maakt ORI-A gebruik van begrippenlijsten van **TOOI**, [een standaardisatieproject opgezet door de Rijksoverheid](https://standaarden.overheid.nl/tooi/doc/tooi-registers/). In andere gevallen beheert ORI-A voorlopig eigen begrippenlijsten. 
+
+Zie ook het [XML-schema](https://ori-a.nl/xml-schema), waar per element dat begrippenlijsten een rol spelen, aangeraden begrippenlijsten zijn opgenomen.
 
 
 # Begrippenlijsten gebruiken


### PR DESCRIPTION
Een terugkomend punt van kritiek op de begrippenlijsten pagina is dat TOOI begrippenlijsten een eigen kopje krijgen, maar de ORI-A begrippenlijsten niet. 

Je kan dat rechttrekken, maar je kan ook besluiten dat dit niet een plek is voor TOOI documentatie. En honestly, ik heb dit kopje ooit op dag 1 van de website toegevoegd, dus er zit verder niet zoveel idee of noodzaak achter. 

## Waarom verwijderen?

Een eigen TOOI begrippenlijstje sectie klinkt misschien mooi, maar ik zie niet echt voor me hoe dat er uit ziet. Nabouwen wat we met de ORI-A begrippenlijsten doen werkt sowieso niet, want doen moeten volledige TOOI waardenlijsten gaan overnemen. Als iemand wel een concreet idee heeft over hoe we dit moeten vormgeven, ben ik benieuwd. 

Moeten we misschien een lijst met elementen bijhouden waar je TOOI begrippenlijsten kan gebruiken, met daaronder weer een lijst me alle mogelijke TOOI begrippenlijsten die van toepassing zijn? Dat schaalt niet heel lekker, want...

1. Elementnamen kunnen veranderen
2. als deze lijst een bepaalde grote bereikt wordt ie onoverzichtelijk
3. voor elk element op deze pagina bijhouden welke TOOI lijsten er bij horen, zou dubbele documentatie opleveren. Momenteel zetten we in `xs:documentatie` namelijk ook al iets over relevante begrippenlijsten:

```xml
<xs:documentation>Gegevens over de bestuurslaag die het agendapunt heeft behandeld. 
Bij voorkeur een waarde uit een TOOI waardenlijst, zoals 'Register gemeenten compleet'.</xs:documentation>
```





Also: een onderverdeling in twee level 1 headers (ORI-A en TOOI) doet af en de overzichtelijkheid van de ORI-A begrippenlijsten, die dan niet meer in de zijbalk komen. 

 # Nieuwe plek voor het documenteren van TOOI begrippenlijsten
 
  > voor elk element op deze pagina bijhouden welke TOOI lijsten er bij horen, zou dubbele documentatie opleveren
  
Zoals gezegd wordt er in de XSD zelf al iets gedocumenteerd over wanneer een  TOOI begrippenlijst mogelijk  van toepassing is. Ik zou dit graag zo laten. Ik stel voor om deze documentatie systematischer en vollediger te maken middels https://github.com/Regionaal-Archief-Rivierenland/ORI-A-XSD/issues/64. Dan is alle informatie over mogelijk relevante begrippenlijsten op element niveau te vinden op de XML-schema pagina, en nergens anders.  

Anders gezegd: na dit voorstel bevat de XML-schema pagina gedetailleerde documentatie op element niveau (inclusief alles wat je over begrippenlijsten wilt weten). De "Begrippenlijsten" pagina dient aan de andere kant alleen nog maar voor  het vastleggen en koppelen van begrippen aan definities.  