### PR TITLE
begrippenlijsten: voeg motie subsoorten toe

### DIFF
--- a/pages/begrippenlijsten.md
+++ b/pages/begrippenlijsten.md
@@ -56,7 +56,7 @@ Als het soort motie onbekend is laat je dit achtervoegsel weg --- `<begripLabel>
 | Motie \| Wantrouwen | Motie van wantrouwen.                                                      |
 | Motie \| Treurnis   | Motie van treurnis.                                                        |
 | Motie \| Afkeuring  | Motie van afkeuring.                                                       |
-| Motie \| Vreemd     | Een motie over een onderwerp dat niet op de agenda staat.                  |
+| Motie \| Vreemd     | Motie over een onderwerp dat niet op de agenda staat.                      |
 | Amendement          | Voorstel om een bestaand voorstel te wijzigen.                             |
 | Toezegging          | Toezegging van een gedeputeerde of raadslid.                               |
 | Vraag               | Vraag aan de raad.                                                         |


### PR DESCRIPTION
TOOI hanteert een zelfde soort mechanisme voor (sub)types (zie bijv. [deze waardenlijst](https://standaarden.overheid.nl/tooi/waardelijsten/expression?lijst_uri=https%3A%2F%2Fidentifier.overheid.nl%2Ftooi%2Fset%2Fccw_plooi_documentsoorten%2F7)). Aangezien dit onderdeel van OG ORI was moeten we hier wel echt iets mee.

Geen idee hoe ik `Motie | Voorstel` moet definieren. Uit wikipedia en de definitie van de VNG maak ik op dat dit type iets te maken heeft met (juridisch) beleid en dagelijks besturen.

https://nl.wikipedia.org/wiki/Motie
https://vng-realisatie.github.io/ODS-Open-Raadsinformatie/catalog

Zou fijn zijn als KOOP dit soort kwesties van ons afneemt.

@lmasrarsaml heb jij betere definities/richtlijnen? Of zelfs een betere manier om voor nu met subtypes te dealen? 