### PR TITLE
Gemeente decentralisatie

### DIFF
--- a/pages/begrippenlijsten.md
+++ b/pages/begrippenlijsten.md
@@ -148,23 +148,23 @@ Met de begrippen uit deze lijst kan de functie of ambt van een [`natuurlijkPerso
 
 | Label                     | Definitie                                                                                     |
 |:--------------------------|:----------------------------------------------------------------------------------------------|
-| Burgemeester              | Voorzitter van het algemeen en dagelijks bestuur van een gemeente.                            |
 | Commissaris van de Koning | Voorzitter van het algemeen en dagelijks bestuur van een provincie.                           |
+| Burgemeester              | Voorzitter van het algemeen en dagelijks bestuur van een gemeente.                            |
 | Dijkgraaf                 | Voorzitter van het algemeen en dagelijks bestuur van een waterschap.                          |
 | Watergraaf                | Voorzitter van het algemeen en dagelijks bestuur van een waterschap.                          |
-| Raadslid                  | Lid van het algemeen bestuur van een gemeente (gemeenteraad)                                  |
 | Statenlid                 | Lid van het algemeen bestuur van een provincie (Provinciale Staten).                          |
-| Wethouder                 | Lid van het dagelijks bestuur van een gemeente (College van burgemeester en wethouders).      |
+| Raadslid                  | Lid van het algemeen bestuur van een gemeente (gemeenteraad)                                  |
+| Algemeen bestuurslid      | Lid van een algemeen bestuur.                                                                 |
 | Gedeputeerde              | Lid van het dagelijks bestuur van een provincie (Gedeputeerde Staten).                        |
+| Wethouder                 | Lid van het dagelijks bestuur van een gemeente (College van burgemeester en wethouders).      |
 | Heemraad                  | Lid van het dagelijks bestuur van een waterschap (College van dijkgraaf en heemraden).        |
 | Hoogheemraad              | Lid van het dagelijks bestuur van een waterschap (College van dijkgraaf en hoogheemraden).    |
 | Dagelijks bestuurslid     | Lid van een dagelijks bestuur.                                                                |
 | Griffier                  | Secretaris van het algemeen bestuur van een gemeente of provincie.                            |
 | Secretaris-directeur      | Secretaris van het algemeen en dagelijks bestuur van een waterschap.                          |
-| Gemeentesecretaris        | Secretaris van het dagelijks bestuur van een gemeente.                                        |
 | Provinciesecretaris       | Secretaris van het dagelijks bestuur van een provincie.                                       |
+| Gemeentesecretaris        | Secretaris van het dagelijks bestuur van een gemeente.                                        |
 | Burgerlid                 | Door het algemeen bestuur van een overheidsorgaan benoemd lid van een commissie of werkgroep. |
-| Algemeen bestuurslid      | Lid van een algemeen bestuur.                                                                 |
 | Ambtenaar/medewerker      | Een overheidsmedewerker.                                                                      |
 | Adviseur of deskundige    | Een door de overheid ingehuurde adviseur of deskundige.                                       |
 | <del>Overig</del>         | -                                                                                             |


### PR DESCRIPTION
Uitwerking van #28.

Op de andere pagina's vond ik eigenlijk geen overtuigende gemeente-centric teksten, behalve dat we de lingo uit gemeenteland gebruiken (raadsinformatie, RIS, gemeente-voorbeeldbestanden). Daar valt niet zoveel aan te doen, behalve duidelijk maken dat ORI-A voor alle overheden geschikt is.

Op begrippenlijsten heb ik vooral de begrippenlijsten aangevuld met termen uit de andere overheidsorganen. Vooral het waterschap is wat dat betreft een wereld op zich, met eigen termen afhankelijk van wat voor soort waterschap het is (aan zee, aan rivieren of meer binnenlands). Daarom zijn er nu soms meerdere termen voor sommige waterschapsonderdelen opgenomen.

Vooral de `<functie>` begrippenlijst is flink aangepakt. Die is op bestuursvolgorde gezet (provincie-gemeente-waterschap) en bevat nu zoveel mogelijk uitputtend alle termen voor de bekendste functies. Maar er zullen er vast een paar missen. Een functienaam voor een algemeen bestuurslid van een waterschap kon ik niet sluitend vinden, dus daar is Algemeen bestuurslid nu de term.

Ik vind `vergaderingstypes` nu eigenlijk de zwakste begrippenlijst, waar naar verwachting de minste systemen aan gaan conformeren. Ik verwacht dat hier tientallen varianten denkbaar zijn, die meer de structuur 'Vergadering van het college van dijkgraaf en heemraden' gaan aannemen in plaats van 'Collegevergadering'. Maar dat zal wel blijken uit toekomstige pilots.