### PR TITLE
over-ori-a: mention een andere manier van subtitles modeleren

### DIFF
--- a/pages/hoe-werkt-ori-a.md
+++ b/pages/hoe-werkt-ori-a.md
@@ -454,4 +454,4 @@ In MDTO druk je dit zo uit:
         …
 ```
 
-Natuurlijk kun je er ook voor kiezen om ondertitels als losse informatieobjecten te modelleren. Dit kan bijvoorbeeld handig zijn als je informatie wilt registreren over de ontstaansgeschiedenis van de ondertitels, zoals of ze automatisch gegeneerd zijn, of wie de auteursrechten in bezit heeft.
+Natuurlijk kun je er ook voor kiezen om ondertitels als losse informatieobjecten te modelleren. Dit kan bijvoorbeeld handig zijn als je informatie wilt registreren over de ontstaansgeschiedenis van de ondertitels, zoals of ze automatisch gegenereerd zijn, of wie de auteursrechten in bezit heeft.


### PR DESCRIPTION
Ik denk dat beide opties prima zijn. De eerste optie de we aankaarten vraagt bijvoorbeeld iets minder moeite/informatie. 

De tweede optie is ook goed om te benoemen, tho, vooral met de opkomst van automatische transcripties en machine translations. 

Is de formulering oke zo? Ik wou er verder niet te veel woorden aan vuil maken.  