### PR TITLE
over-ori-a: verwijder alinea

### DIFF
--- a/pages/over-ori-a.md
+++ b/pages/over-ori-a.md
@@ -15,8 +15,6 @@ ORI-A is gebaseerd op het informatiemodel dat de VNG heeft ontworpen voor [de Op
 
 # Waarom is ORI-A ontwikkeld?
 
-Tijdens een [landelijke bijeenkomst over videotulen](https://kiacommunity.nl/thoughts/11904) bleek er behoefte te zijn aan een standaard voor het duurzaam bewaren en beschikbaarstellen van raadsinformatie in een digitale archiefbewaarplaats (het e-depot). De toen opgerichte [Werkgroep Archivering Raadsinformatie](colofon) stelde zich als taak deze standaard te realiseren. ORI-A is daarvan het resultaat.
-
 ORI-A heeft hetzelfde hoofddoel als het ORI project van de VNG: het gestandaardiseerd beschikbaar stellen van raadsinformatie. Deze standaardisatieslag is hard nodig, omdat ieder raadsinformatiesysteem (RIS) momenteel een eigen, niet-publiek gedocumenteerd formaat voor raadsinformatie hanteert. Hiermee komt de toekomstige **vindbaarheid** en **interpreteerbaarheid** van raadsinformatie in gevaar.
 
 De ORI-standaard van de VNG voldeed echter niet volledig aan de behoeften van archiefdiensten, waaronder [de mogelijkheid tot integratie met **MDTO**](hoe-werkt-ori-a#ori-a-mdto-combineren). Hierom is besloten een archiefvariant van ORI te ontwikkelen. Je kan hier meer over lezen in [Waarom een speciale archiefstandaard?](faq#waarom-een-speciale-archiefstandaard)


### PR DESCRIPTION
Ik vind onze voorpagina eigenlijk te lang. 3 alineas voor een soort half antwoord op "Waarom" is overdreven. 

Alhoewel deze alinea misschien iets meer sense maakte onder een kopje over de ontstaansgeschiedenis van ORI-A, waar hij eerst stond, moeten we ons denk ik blijven afvragen wat voor informatie elk stuk tekst verschaft.

Concreter gezegd: op de vraag "Waarom ORI-A" is het antwoord nu:

> er was behoefte aan ... een standaard voor het duurzaam bewaren en beschikbaarstellen van raadsinformatie [i.e. ORI-A]

Oftewel, ORI-A bestaat omdat er behoefte was aan ORI-A. Als dit niet circulair is, is het in ieder geval vrij leeg.

(_dat_ er behoefte was aan ORI-A spreekt min of meer voor zich als je op de website ORI-A.nl bent - wat we moeten beantwoorden is bijv. op welke niches ORI-A inspeelt, of waarom mensen ORI-A moeten gebruiken, wat je er mee kan bereiken, etc.) 

# Resultaat

Door deze alinea te verwijderen gaat er weinig informatie verloren en word de voorpagina een stuk scanbaarder.  

# Alternatieven voor het "Waarom" kopje

De meeste technische documentatie websites zijn niet alleen veel beknopter, maar hebben een mooi lijstje met bullets onder hun "Waarom ..." equivalent:

* https://ziglang.org/
* https://fishshell.com/docs/current/#
* https://docs.astral.sh/uv/
* https://docs.deno.com/runtime/

Ik zie liever dat wij hier ook naar toe gaan. De voorpagina moet meer dan elke pagina scanbaar zijn , en daar falen we nu imo in (bronnen: https://www.stylemanual.gov.au/accessible-and-inclusive-content/how-people-read ; https://www.writethedocs.org/guide/writing/docs-principles/#skimmable).