### PR TITLE
begrippenlijsten: missende vraag subsoorten

### DIFF
--- a/pages/begrippenlijsten.md
+++ b/pages/begrippenlijsten.md
@@ -44,24 +44,27 @@ ORI-A onderscheidt verschillende soorten moties. Als het soort motie bekend is, 
    …
 ```
 
-Als het soort motie onbekend is laat je dit achtervoegsel weg --- `<begripLabel>` is in dat geval gewoon gelijk aan `Motie`.
+Als het soort motie onbekend is laat je dit achtervoegsel weg --- `<begripLabel>` is in dat geval gewoon gelijk aan `Motie`. Dezelfde hiërarchische classificatie wordt gebruikt voor `Vraag`.
 
 
-| Label               | Definitie                                                                  |
-|:--------------------|:---------------------------------------------------------------------------|
-| Voorstel            | Plan waarover een besluit genomen kan worden.                              |
-| Motie               | Gemotiveerde verklaring waardoor een mening of verzoek wordt uitgesproken. |
-| Motie \| Voorstel   | Motie met een voorstel tot handelen.                                       |
-| Motie \| Wantrouwen | Motie van wantrouwen.                                                      |
-| Motie \| Treurnis   | Motie van treurnis.                                                        |
-| Motie \| Afkeuring  | Motie van afkeuring.                                                       |
-| Motie \| Vreemd     | Motie over een onderwerp dat niet op de agenda staat.                      |
-| Amendement          | Voorstel om een bestaand voorstel te wijzigen.                             |
-| Toezegging          | Toezegging van een gedeputeerde of raadslid.                               |
-| Vraag               | Vraag aan de raad.                                                         |
-| Antwoord            | Antwoord op een vraag aan de raad.                                         |
-| Ingekomen stuk      | Een stuk gericht aan de raad.                                              |
-| Mededeling          | Een mededeling.                                                            |
+| Label                                  | Definitie                                                                  |
+|:---------------------------------------|:---------------------------------------------------------------------------|
+| Voorstel                               | Plan waarover een besluit genomen kan worden.                              |
+| Motie                                  | Gemotiveerde verklaring waardoor een mening of verzoek wordt uitgesproken. |
+| Motie \| Voorstel                      | Motie met een voorstel tot handelen.                                       |
+| Motie \| Wantrouwen                    | Motie van wantrouwen.                                                      |
+| Motie \| Treurnis                      | Motie van treurnis.                                                        |
+| Motie \| Afkeuring                     | Motie van afkeuring.                                                       |
+| Motie \| Vreemd                        | Motie over een onderwerp dat niet op de agenda staat.                      |
+| Amendement                             | Voorstel om een bestaand voorstel te wijzigen.                             |
+| Toezegging                             | Toezegging van een gedeputeerde of raadslid.                               |
+| Vraag                                  | Vraag aan een overheidsorgaan.                                             |
+| Vraag \| Technische vraag              | Vraag naar feitelijke informatie.                                          |
+| Vraag \| Schriftelijke politieke vraag | Schriftelijk ingediende vraag over een politiek standpunt.                 |
+| Vraag \| Mondelinge politieke vraag    | Mondelinge vraag over een politiek standpunt.                              |
+| Antwoord                               | Antwoord op een vraag.                                                     |
+| Ingekomen stuk                         | Een stuk gericht aan de raad.                                              |
+| Mededeling                             | Een mededeling.                                                            |
 
 
 # Deelnemerrollen


### PR DESCRIPTION
Deze subsoorten zijn onderdeel van het oorspronkelijke ORI-informatiemodel:

<img width="918" height="491" alt="image" src="https://github.com/user-attachments/assets/2307ca72-b850-4f48-9005-86ee1e99fce8" />
<img width="421" height="439" alt="image" src="https://github.com/user-attachments/assets/79de6d2f-d049-4819-be5d-d3b8806b26a6" />

Deze subsoorten kun je nu op dezelfde manier specificeren als bij motie-subsoorten. 

## Formulering

Om comptabiliteit met OG ORI te garanderen moet er een manier zijn deze subtypes te specificeren. 

Waar we wel aan kunnen sleutelen is hoe we deze nieuwe begrippen _definiëren_. Voor mijn huidige formulering baseer ik me op https://raad.purmerend.nl/gemeenteraad/instrumenten en https://www.gennep.nl/instrumenten-van-de-raad. 

Ze zijn wel iets algemener dan die formuleringen, zodat de begrippen ook eventueel kunnen worden toegepast in niet-gemeenteraad contexten. 

In die lijn doet deze PR wat kleine — niet geheel koshere —  tweaks aan bestaande `Vraag`-gerelateerde formulering die gemeente-bias bevatten. Niet alle gemeente-bias is hiermee uit deze begrippenlijst weggenomen, tho, want dan zou deze PR te groot en heterogeen worden.
